### PR TITLE
Pin GitHub actions by hash

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -19,7 +19,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4.1.6
+    - name: Checkout
+      uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
     # For unknown reasons, pre-commit fails with error: component download failed for cargo-x86_64-unknown-linux-gnu: could not rename downloaded file ...
     # unless we install with rustup first manually.
     - name: Update rust
@@ -28,15 +29,17 @@ jobs:
       run: rustup component add rustfmt
     - name: Install clippy
       run: rustup component add clippy
-    - uses: actions/cache@v4.0.2
+    - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
       with:
         path: |
           ~/.cache/pre-commit/
         key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
-    - uses: actions/setup-python@v5.1.0
+    - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
       with:
-        python-version: '3.12'
-    - name: Install pre-commit
-      run: pip install -r .github/workflows/pre-commit-requirements.txt
+        python-version: "3.12"
+    - name: Set up Python environment
+      uses: glotzerlab/workflows/setup-uv@5cfac9da9cb78e16ae97a9119b6fd13c1c2d6f5e # 0.1.0
+      with:
+        lockfile: ".github/workflows/pre-commit-requirements.txt"
     - name: Run pre-commit
       run: pre-commit run --all-files

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4.1.6
+    - name: Checkout
+      uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       with:
         path: code
 
@@ -50,7 +51,7 @@ jobs:
     - name: Tar/xz source
       run: tar -cvJf "${name}-${ref}.tar.xz" "${name}-${ref}"
 
-    - uses: actions/upload-artifact@v4.3.3
+    - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
         name: source
         path: |
@@ -61,7 +62,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4.1.6
+    - name: Checkout
+      uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       with:
         path: code
 
@@ -80,7 +82,7 @@ jobs:
         tee "${GITHUB_WORKSPACE}/release-notes.md"
       working-directory: code
 
-    - uses: actions/upload-artifact@v4.3.3
+    - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
         name: release-notes
         path: |
@@ -101,14 +103,15 @@ jobs:
           runner: macos-14
 
     steps:
-    - uses: actions/checkout@v4.1.6
+    - name: Checkout
+      uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
     - name: Determine filename-safe ref from GITHUB_REF_NAME
       run: echo ref="$(echo "${GITHUB_REF_NAME}" | sed  -e 's/\//-/g')" >> "$GITHUB_ENV"
     - name: Update rust
       run: rustup install "$RUST_VERSION" --no-self-update && rustup default "$RUST_VERSION"
     - name: Check rust installation
       run: rustc -vV
-    - uses: actions/cache@v4.0.2
+    - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
       with:
         path: |
           ~/.cargo/registry/index/
@@ -122,7 +125,7 @@ jobs:
       run: file "target/${{ matrix.target }}/release/${name}"
     - name: Compress
       run: cp "target/${{ matrix.target }}/release/${name}" . && tar -cvJf "${name}-${ref}-${{ matrix.target }}.tar.xz" "${name}"
-    - uses: actions/upload-artifact@v4.3.3
+    - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
         name: ${{ matrix.target }}
         path: "${{ env.name }}-${{ env.ref }}-${{ matrix.target }}.tar.xz"
@@ -134,7 +137,7 @@ jobs:
 
     steps:
     - name: Download artifacts
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
       with:
         merge-multiple: true
 
@@ -142,7 +145,7 @@ jobs:
       run: ls -lR
 
     - name: Create release
-      uses: softprops/action-gh-release@v2.0.5
+      uses: softprops/action-gh-release@69320dbe05506a9a39fc8ae11030b214ec2d1f87 # v2.0.5
       if: startsWith(github.ref, 'refs/tags/')
       with:
         files: |
@@ -156,12 +159,13 @@ jobs:
     name: Publish [Cargo]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4.1.6
+    - name: Checkout
+      uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
     - name: Update rust
       run: rustup install "$RUST_VERSION" --no-self-update && rustup default "$RUST_VERSION"
     - name: Check rust installation
       run: rustc -vV
-    - uses: actions/cache@v4.0.2
+    - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
       with:
         path: |
           ~/.cargo/registry/index/

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -8,31 +8,4 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Run stale action
-      uses: actions/stale@v9.0.0
-      with:
-        operations-per-run: 120
-        delete-branch: true
-        days-before-close: 10
-        stale-issue-label: stale
-        stale-pr-label: stale
-        exempt-issue-labels: essential
-        exempt-pr-labels: essential
-
-        days-before-issue-stale: 260
-        stale-issue-message: >
-          This issue has been automatically marked as stale because it has not had
-          recent activity. It will be closed if no further activity occurs.
-        close-issue-message: >
-          This issue has been automatically closed because it has not had
-          recent activity.
-
-        days-before-pr-stale: 20
-        stale-pr-message: >
-          This pull request has been automatically marked as stale because it has not had
-          recent activity. It will be closed if no further activity occurs.
-        close-pr-message: >
-          This pull request has been automatically closed because it has not had
-          recent activity.
+    uses: glotzerlab/workflows/.github/workflows/stale.yaml@5cfac9da9cb78e16ae97a9119b6fd13c1c2d6f5e # 0.1.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,10 +20,7 @@ env:
   CARGO_TERM_COLOR: always
   ROW_COLOR: always
   CLICOLOR: 1
-  MDBOOK_VERSION: 0.4.40
-  LINKCHECK_VERSION: 0.7.7
   RUST_LATEST_VERSION: 1.78.0
-  BUNDLE_LICENSES_VERSION: 1.3.0
 
 jobs:
   unit_test:
@@ -48,12 +45,13 @@ jobs:
           mode: release
 
     steps:
-    - uses: actions/checkout@v4.1.6
+    - name: Checkout
+      uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
     - name: Update rust
       run: rustup install ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
     - name: Check rust installation
       run: rustc -vV
-    - uses: actions/cache@v4.0.2
+    - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
       with:
         path: |
           ~/.cargo/registry/index/
@@ -70,12 +68,13 @@ jobs:
     name: Execute tutorials
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4.1.6
+    - name: Checkout
+      uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
     - name: Update rust
       run: rustup install "$RUST_LATEST_VERSION" --no-self-update && rustup default "$RUST_LATEST_VERSION"
     - name: Check rust installation
       run: rustc -vV
-    - uses: actions/cache@v4.0.2
+    - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
       with:
         path: |
           ~/.cargo/registry/index/
@@ -97,10 +96,13 @@ jobs:
         ROW_YES: "true"
     # The signac test requires python
     - name: Set up Python
-      uses: actions/setup-python@v5.1.0
+      uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
       with:
-        python-version: '3.12'
-    - run: pip install -r .github/workflows/signac-requirements.txt
+        python-version: "3.12"
+    - name: Set up Python environment
+      uses: glotzerlab/workflows/setup-uv@5cfac9da9cb78e16ae97a9119b6fd13c1c2d6f5e # 0.1.0
+      with:
+        lockfile: ".github/workflows/signac-requirements.txt"
     - name: Run signac.sh
       run: bash signac.sh
       working-directory: doc/src/guide/python
@@ -111,16 +113,10 @@ jobs:
     name: Build documentation
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4.1.6
-    - name: Install mdbook
-      run: |
-        mkdir -p "$HOME/.cargo/bin"
-        curl -sSL "https://github.com/rust-lang/mdBook/releases/download/v$MDBOOK_VERSION/mdbook-v$MDBOOK_VERSION-x86_64-unknown-linux-gnu.tar.gz" | tar -xvz --directory "$HOME/.cargo/bin"
-    - name: Install mdbook-linkcheck
-      run: |
-        curl -sSL "https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v$LINKCHECK_VERSION/mdbook-linkcheck.x86_64-unknown-linux-gnu.zip" -o mdbook-linkcheck.zip
-        unzip mdbook-linkcheck.zip -d "$HOME/.cargo/bin"
-        chmod a+x "$HOME/.cargo/bin/mdbook-linkcheck"
+    - name: Checkout
+      uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+    - name: Set up mdbook
+      uses: glotzerlab/workflows/setup-mdbook@5cfac9da9cb78e16ae97a9119b6fd13c1c2d6f5e # 0.1.0
     - name: Add linkcheck configuration
       run: |
         echo -e "[output.linkcheck]\nfollow-web-links=true" >> doc/book.toml
@@ -129,10 +125,8 @@ jobs:
       run: mdbook build doc
       env:
         RUST_LOG: "mdbook=info,linkcheck=warn,reqwest=debug"
-    - name: Install cargo-bundle-licenses
-      run: |
-        curl -sSL "https://github.com/sstadick/cargo-bundle-licenses/releases/download/v$BUNDLE_LICENSES_VERSION/cargo-bundle-licenses-linux-amd64" -o "$HOME/.cargo/bin/cargo-bundle-licenses"
-        chmod a+x "$HOME/.cargo/bin/cargo-bundle-licenses"
+    - name: Set up mdbook
+      uses: glotzerlab/workflows/setup-cargo-bundle-licenses@5cfac9da9cb78e16ae97a9119b6fd13c1c2d6f5e # 0.1.0
     - name: Check bundled licenses
       run: cargo bundle-licenses --format yaml --output CI.yaml --previous THIRDPARTY.yaml --check-previous
 


### PR DESCRIPTION
## Description

<!-- Describe your changes. -->
Follow security recommendations and pin all GitHub actions by hash.
Also make use of reusable workflows and actions.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
* Ensure that rewritten tags on upstream repositories cannot be used to execute arbitrary code in our CI.
* Reduce the amount of code duplication between projects. Provide a single place to update tools to the latest version.

## How has this been tested?

<!--- Please describe how you tested your changes. -->
CI checks.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/row/blob/trunk/doc/src/developers/contributing.md).
- [x] I agree with the terms of the [**Row Contributor Agreement**](https://github.com/glotzerlab/row/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/src/contributors.md`) in the pull request source branch.
- [ ] I have added a change log entry to `doc/src/release-notes.md`.
