### PR TITLE
Add warn_[cpus|gpus]_not_multiple_of and logic

### DIFF
--- a/doc/src/clusters/cluster.md
+++ b/doc/src/clusters/cluster.md
@@ -79,6 +79,18 @@ partition **must** use an integer multiple of the given number of cpus:
 total_cpus % require_cpus_multiple_of == 0
 ```
 
+### prefer_cpus_multiple_of
+
+`cluster.partition.require_cpus_multiple_of`: **integer** - All jobs submitted to this
+partition **should** use an integer multiple of the given number of cpus:
+```plaintext
+if not (total_cpus % require_cpus_multiple_of == 0):
+  warn! ...
+```
+
+This is a nonblocking variant of `require_cpus_multiple_of` that allows for submission
+of jobs that underutilize resources.
+
 ### memory_per_cpu
 
 `cluster.partition.memory_per_cpu`: **string** - CPU Jobs submitted to this partition
@@ -123,6 +135,18 @@ partition **must** use an integer multiple of the given number of gpus:
 ```plaintext
 total_gpus % require_gpus_multiple_of == 0
 ```
+
+### prefer_gpus_multiple_of
+
+`cluster.partition.require_gpus_multiple_of`: **integer** - All jobs submitted to this
+partition **should** use an integer multiple of the given number of gpus:
+```plaintext
+if not (total_gpus % require_gpus_multiple_of == 0):
+  warn! ...
+```
+
+This is a nonblocking variant of `require_gpus_multiple_of` that allows for submission
+of jobs that underutilize resources.
 
 ### memory_per_gpu
 

--- a/doc/src/clusters/cluster.md
+++ b/doc/src/clusters/cluster.md
@@ -79,12 +79,12 @@ partition **must** use an integer multiple of the given number of cpus:
 total_cpus % require_cpus_multiple_of == 0
 ```
 
-### prefer_cpus_multiple_of
+### warn_cpus_not_multiple_of
 
-`cluster.partition.require_cpus_multiple_of`: **integer** - All jobs submitted to this
+`cluster.partition.warn_cpus_not_multiple_of`: **integer** - All jobs submitted to this
 partition **should** use an integer multiple of the given number of cpus:
 ```plaintext
-if not (total_cpus % require_cpus_multiple_of == 0):
+if total_cpus % warn_cpus_not_multiple_of != 0:
   warn! ...
 ```
 
@@ -136,12 +136,12 @@ partition **must** use an integer multiple of the given number of gpus:
 total_gpus % require_gpus_multiple_of == 0
 ```
 
-### prefer_gpus_multiple_of
+### warn_gpus_not_multiple_of
 
-`cluster.partition.require_gpus_multiple_of`: **integer** - All jobs submitted to this
+`cluster.partition.warn_gpus_not_multiple_of`: **integer** - All jobs submitted to this
 partition **should** use an integer multiple of the given number of gpus:
 ```plaintext
-if not (total_gpus % require_gpus_multiple_of == 0):
+if total_gpus % warn_gpus_not_multiple_of != 0:
   warn! ...
 ```
 

--- a/doc/src/contributors.md
+++ b/doc/src/contributors.md
@@ -3,3 +3,4 @@
 The following people have contributed to the development of **row**:
 
 * Joshua A. Anderson, University of Michigan
+* Jen Bradley, University of Michigan

--- a/doc/src/release-notes.md
+++ b/doc/src/release-notes.md
@@ -1,5 +1,15 @@
 # Release notes
 
+## 0.1.4 (2024-06-13)
+
+*Added:*
+
+* `warn_[cpus|gpus]_multiple_of` key for *clusters.toml*
+
+*Changed*
+
+* OLCF Frontier configuration now uses `warn_gpus_multiple_of` instead of `require_gpus_multiple_of`
+
 ## 0.1.3 (2024-05-30)
 
 *Fixed:*

--- a/doc/src/release-notes.md
+++ b/doc/src/release-notes.md
@@ -6,7 +6,7 @@
 
 * `warn_[cpus|gpus]_multiple_of` key for *clusters.toml*
 
-*Changed*
+*Changed:*
 
 * OLCF Frontier configuration now uses `warn_gpus_multiple_of` instead of `require_gpus_multiple_of`
 

--- a/doc/src/release-notes.md
+++ b/doc/src/release-notes.md
@@ -4,11 +4,11 @@
 
 *Added:*
 
-* `warn_[cpus|gpus]_multiple_of` key for *clusters.toml*
+* `prefer_[cpus|gpus]_multiple_of` key for *clusters.toml*
 
 *Changed:*
 
-* OLCF Frontier configuration now uses `warn_gpus_multiple_of` instead of `require_gpus_multiple_of`
+* OLCF Frontier configuration now uses `prefer_gpus_multiple_of` instead of `require_gpus_multiple_of`
 
 ## 0.1.3 (2024-05-30)
 

--- a/doc/src/release-notes.md
+++ b/doc/src/release-notes.md
@@ -4,11 +4,12 @@
 
 *Added:*
 
-* `prefer_[cpus|gpus]_multiple_of` key for *clusters.toml*
+* `warn_[cpus|gpus]_not_multiple_of` key for *clusters.toml*
 
 *Changed:*
 
-* OLCF Frontier configuration now uses `prefer_gpus_multiple_of` instead of `require_gpus_multiple_of`
+* OLCF Frontier configuration now uses `warn_gpus_not_multiple_of` instead of `require_gpus_multiple_of`
+* OLCF Andes configuration now uses `warn_cpus_not_multiple_of` instead of `require_cpus_multiple_of`
 
 ## 0.1.3 (2024-05-30)
 

--- a/doc/src/release-notes.md
+++ b/doc/src/release-notes.md
@@ -1,6 +1,6 @@
 # Release notes
 
-## 0.1.4 (2024-06-13)
+## 0.2.0 (not yet released)
 
 *Added:*
 

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -77,7 +77,7 @@ fn andes() -> Cluster {
             Partition {
                 name: "batch".into(),
                 maximum_gpus_per_job: Some(0),
-                require_cpus_multiple_of: Some(32),
+                prefer_cpus_multiple_of: Some(32),
                 cpus_per_node: Some(32),
                 ..Partition::default()
             },

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -77,7 +77,7 @@ fn andes() -> Cluster {
             Partition {
                 name: "batch".into(),
                 maximum_gpus_per_job: Some(0),
-                prefer_cpus_multiple_of: Some(32),
+                warn_cpus_not_multiple_of: Some(32),
                 cpus_per_node: Some(32),
                 ..Partition::default()
             },
@@ -210,7 +210,7 @@ fn frontier() -> Cluster {
             // Auto-detected partitions: batch
             Partition {
                 name: "batch".into(),
-                prefer_gpus_multiple_of: Some(8),
+                warn_gpus_not_multiple_of: Some(8),
                 gpus_per_node: Some(8),
                 ..Partition::default()
             },

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -210,7 +210,7 @@ fn frontier() -> Cluster {
             // Auto-detected partitions: batch
             Partition {
                 name: "batch".into(),
-                warn_gpus_multiple_of: Some(8),
+                prefer_gpus_multiple_of: Some(8),
                 gpus_per_node: Some(8),
                 ..Partition::default()
             },

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -210,8 +210,7 @@ fn frontier() -> Cluster {
             // Auto-detected partitions: batch
             Partition {
                 name: "batch".into(),
-                minimum_gpus_per_job: Some(8),
-                require_gpus_multiple_of: Some(8),
+                warn_gpus_multiple_of: Some(8),
                 gpus_per_node: Some(8),
                 ..Partition::default()
             },

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -81,6 +81,9 @@ pub struct Partition {
     /// Require CPUs to be a multiple of this value.
     pub require_cpus_multiple_of: Option<usize>,
 
+    /// Warn if CPUs are not a multiple of this value.
+    pub warn_cpus_multiple_of: Option<usize>,
+
     /// Memory per CPU.
     pub memory_per_cpu: Option<String>,
 
@@ -95,6 +98,9 @@ pub struct Partition {
 
     /// Require GPUs to be a multiple of this value.
     pub require_gpus_multiple_of: Option<usize>,
+
+    /// Warn if GPUs are not a multiple of this value.
+    pub warn_gpus_multiple_of: Option<usize>,
 
     /// Memory per GPU.
     pub memory_per_gpu: Option<String>,
@@ -295,6 +301,18 @@ impl Partition {
             return false;
         }
 
+        if self
+            .warn_cpus_multiple_of
+            .map_or(false, |x| total_cpus % x != 0)
+        {
+            let _ = writeln!(
+                reason,
+                "{}: CPUs ({}) not a recommended multiple.",
+                self.name, total_cpus
+            );
+            return true;
+        }
+
         if self.minimum_gpus_per_job.map_or(false, |x| total_gpus < x) {
             let _ = writeln!(reason, "{}: Not enough GPUs ({}).", self.name, total_gpus);
             return false;
@@ -319,6 +337,18 @@ impl Partition {
                 self.name, total_gpus
             );
             return false;
+        }
+
+        if self
+            .warn_gpus_multiple_of
+            .map_or(false, |x| total_gpus == 0 || total_gpus % x != 0)
+        {
+            let _ = writeln!(
+                reason,
+                "{}: GPUs ({}) not a recommended multiple. ",
+                self.name, total_gpus
+            );
+            return true;
         }
 
         true

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -363,11 +363,13 @@ impl Default for Partition {
             memory_per_cpu: None,
             cpus_per_node: None,
             require_cpus_multiple_of: None,
+            warn_cpus_multiple_of: None,
             minimum_gpus_per_job: None,
             maximum_gpus_per_job: None,
             memory_per_gpu: None,
             gpus_per_node: None,
             require_gpus_multiple_of: None,
+            warn_gpus_multiple_of: None,
             prevent_auto_select: false,
             account_suffix: None,
         }

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -310,7 +310,7 @@ impl Partition {
                 "{}: CPUs ({}) not a recommended multiple.",
                 self.name, total_cpus
             );
-            return true;
+            return true; // Issuing this warning does not prevent use of the partition.
         }
 
         if self.minimum_gpus_per_job.map_or(false, |x| total_gpus < x) {
@@ -348,7 +348,7 @@ impl Partition {
                 "{}: GPUs ({}) not a recommended multiple. ",
                 self.name, total_gpus
             );
-            return true;
+            return true; // Issuing this warning does not prevent use of the partition.
         }
 
         true

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2024 The Regents of the University of Michigan.
 // Part of row, released under the BSD 3-Clause License.
 
-use log::{debug, info, trace};
+use log::{debug, info, trace, warn};
 use serde::{Deserialize, Serialize};
 use std::env;
 use std::fmt::Write as _;
@@ -305,8 +305,7 @@ impl Partition {
             .warn_cpus_multiple_of
             .map_or(false, |x| total_cpus % x != 0)
         {
-            let _ = writeln!(
-                reason,
+            warn!(
                 "{}: CPUs ({}) not a recommended multiple.",
                 self.name, total_cpus
             );
@@ -343,8 +342,7 @@ impl Partition {
             .warn_gpus_multiple_of
             .map_or(false, |x| total_gpus == 0 || total_gpus % x != 0)
         {
-            let _ = writeln!(
-                reason,
+            warn!(
                 "{}: GPUs ({}) not a recommended multiple. ",
                 self.name, total_gpus
             );

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -755,10 +755,12 @@ scheduler = "slurm"
 name = "d"
 maximum_cpus_per_job = 2
 require_cpus_multiple_of = 4
+warn_cpus_multiple_of = 4
 memory_per_cpu = "e"
 minimum_gpus_per_job = 8
 maximum_gpus_per_job = 16
 require_gpus_multiple_of = 32
+warn_gpus_multiple_of = 32
 memory_per_gpu = "f"
 cpus_per_node = 10
 gpus_per_node = 11
@@ -784,10 +786,12 @@ account_suffix = "-gpu"
 
                 maximum_cpus_per_job: Some(2),
                 require_cpus_multiple_of: Some(4),
+                warn_cpus_multiple_of: Some(4),
                 memory_per_cpu: Some("e".into()),
                 minimum_gpus_per_job: Some(8),
                 maximum_gpus_per_job: Some(16),
                 require_gpus_multiple_of: Some(32),
+                warn_gpus_multiple_of: Some(32),
                 memory_per_gpu: Some("f".into()),
                 prevent_auto_select: false,
                 cpus_per_node: Some(10),

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -82,7 +82,7 @@ pub struct Partition {
     pub require_cpus_multiple_of: Option<usize>,
 
     /// Warn if CPUs are not a multiple of this value.
-    pub warn_cpus_multiple_of: Option<usize>,
+    pub prefer_cpus_multiple_of: Option<usize>,
 
     /// Memory per CPU.
     pub memory_per_cpu: Option<String>,
@@ -100,7 +100,7 @@ pub struct Partition {
     pub require_gpus_multiple_of: Option<usize>,
 
     /// Warn if GPUs are not a multiple of this value.
-    pub warn_gpus_multiple_of: Option<usize>,
+    pub prefer_gpus_multiple_of: Option<usize>,
 
     /// Memory per GPU.
     pub memory_per_gpu: Option<String>,
@@ -302,11 +302,11 @@ impl Partition {
         }
 
         if self
-            .warn_cpus_multiple_of
+            .prefer_cpus_multiple_of
             .map_or(false, |x| total_cpus % x != 0)
         {
             warn!(
-                "{}: CPUs ({}) not a recommended multiple.",
+                "{}: CPUs ({}) not a preferred multiple.",
                 self.name, total_cpus
             );
             return true; // Issuing this warning does not prevent use of the partition.
@@ -339,11 +339,11 @@ impl Partition {
         }
 
         if self
-            .warn_gpus_multiple_of
+            .prefer_gpus_multiple_of
             .map_or(false, |x| total_gpus == 0 || total_gpus % x != 0)
         {
             warn!(
-                "{}: GPUs ({}) not a recommended multiple. ",
+                "{}: GPUs ({}) not a preferred multiple. ",
                 self.name, total_gpus
             );
             return true; // Issuing this warning does not prevent use of the partition.
@@ -361,13 +361,13 @@ impl Default for Partition {
             memory_per_cpu: None,
             cpus_per_node: None,
             require_cpus_multiple_of: None,
-            warn_cpus_multiple_of: None,
+            prefer_cpus_multiple_of: None,
             minimum_gpus_per_job: None,
             maximum_gpus_per_job: None,
             memory_per_gpu: None,
             gpus_per_node: None,
             require_gpus_multiple_of: None,
-            warn_gpus_multiple_of: None,
+            prefer_gpus_multiple_of: None,
             prevent_auto_select: false,
             account_suffix: None,
         }
@@ -753,12 +753,12 @@ scheduler = "slurm"
 name = "d"
 maximum_cpus_per_job = 2
 require_cpus_multiple_of = 4
-warn_cpus_multiple_of = 4
+prefer_cpus_multiple_of = 4
 memory_per_cpu = "e"
 minimum_gpus_per_job = 8
 maximum_gpus_per_job = 16
 require_gpus_multiple_of = 32
-warn_gpus_multiple_of = 32
+prefer_gpus_multiple_of = 32
 memory_per_gpu = "f"
 cpus_per_node = 10
 gpus_per_node = 11
@@ -784,12 +784,12 @@ account_suffix = "-gpu"
 
                 maximum_cpus_per_job: Some(2),
                 require_cpus_multiple_of: Some(4),
-                warn_cpus_multiple_of: Some(4),
+                prefer_cpus_multiple_of: Some(4),
                 memory_per_cpu: Some("e".into()),
                 minimum_gpus_per_job: Some(8),
                 maximum_gpus_per_job: Some(16),
                 require_gpus_multiple_of: Some(32),
-                warn_gpus_multiple_of: Some(32),
+                prefer_gpus_multiple_of: Some(32),
                 memory_per_gpu: Some("f".into()),
                 prevent_auto_select: false,
                 cpus_per_node: Some(10),

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -82,7 +82,7 @@ pub struct Partition {
     pub require_cpus_multiple_of: Option<usize>,
 
     /// Warn if CPUs are not a multiple of this value.
-    pub prefer_cpus_multiple_of: Option<usize>,
+    pub warn_cpus_not_multiple_of: Option<usize>,
 
     /// Memory per CPU.
     pub memory_per_cpu: Option<String>,
@@ -100,7 +100,7 @@ pub struct Partition {
     pub require_gpus_multiple_of: Option<usize>,
 
     /// Warn if GPUs are not a multiple of this value.
-    pub prefer_gpus_multiple_of: Option<usize>,
+    pub warn_gpus_not_multiple_of: Option<usize>,
 
     /// Memory per GPU.
     pub memory_per_gpu: Option<String>,
@@ -302,7 +302,7 @@ impl Partition {
         }
 
         if self
-            .prefer_cpus_multiple_of
+            .warn_cpus_not_multiple_of
             .map_or(false, |x| total_cpus % x != 0)
         {
             warn!(
@@ -339,7 +339,7 @@ impl Partition {
         }
 
         if self
-            .prefer_gpus_multiple_of
+            .warn_gpus_not_multiple_of
             .map_or(false, |x| total_gpus == 0 || total_gpus % x != 0)
         {
             warn!(
@@ -361,13 +361,13 @@ impl Default for Partition {
             memory_per_cpu: None,
             cpus_per_node: None,
             require_cpus_multiple_of: None,
-            prefer_cpus_multiple_of: None,
+            warn_cpus_not_multiple_of: None,
             minimum_gpus_per_job: None,
             maximum_gpus_per_job: None,
             memory_per_gpu: None,
             gpus_per_node: None,
             require_gpus_multiple_of: None,
-            prefer_gpus_multiple_of: None,
+            warn_gpus_not_multiple_of: None,
             prevent_auto_select: false,
             account_suffix: None,
         }
@@ -753,12 +753,12 @@ scheduler = "slurm"
 name = "d"
 maximum_cpus_per_job = 2
 require_cpus_multiple_of = 4
-prefer_cpus_multiple_of = 4
+warn_cpus_not_multiple_of = 4
 memory_per_cpu = "e"
 minimum_gpus_per_job = 8
 maximum_gpus_per_job = 16
 require_gpus_multiple_of = 32
-prefer_gpus_multiple_of = 32
+warn_gpus_not_multiple_of = 32
 memory_per_gpu = "f"
 cpus_per_node = 10
 gpus_per_node = 11
@@ -784,12 +784,12 @@ account_suffix = "-gpu"
 
                 maximum_cpus_per_job: Some(2),
                 require_cpus_multiple_of: Some(4),
-                prefer_cpus_multiple_of: Some(4),
+                warn_cpus_not_multiple_of: Some(4),
                 memory_per_cpu: Some("e".into()),
                 minimum_gpus_per_job: Some(8),
                 maximum_gpus_per_job: Some(16),
                 require_gpus_multiple_of: Some(32),
-                prefer_gpus_multiple_of: Some(32),
+                warn_gpus_not_multiple_of: Some(32),
                 memory_per_gpu: Some("f".into()),
                 prevent_auto_select: false,
                 cpus_per_node: Some(10),


### PR DESCRIPTION
## Description

Add additional keys to warn users when their job is of an unexpected size. Update Frontier default configuration to use the new keys.

## Motivation and context

On clusters with no shared partition, some jobs need to request more resources than strictly required in order for the allocation to be granted. Adding a warning configuration option will give users feedback on underutilized jobs without preventing these partial jobs from running.

Note that warnings are returned *after* the job submission is confirmed.

## How has this been tested?

Existing tests have been updated to use the new keys. Due to the nature of the warnings, it is nontrivial to add new tests. This can be addressed in a later PR.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/row/blob/trunk/doc/src/developers/contributing.md).
- [x] I agree with the terms of the [**Row Contributor Agreement**](https://github.com/glotzerlab/row/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/src/contributors.md`) in the pull request source branch.
- [x] I have added a change log entry to `doc/src/release-notes.md`.
