### PR TITLE
Fix `gpus-per-task is mutually exclusive with tres-per-task` error.

### DIFF
--- a/doc/src/clusters/built-in.md
+++ b/doc/src/clusters/built-in.md
@@ -4,7 +4,7 @@
 
 ## Andes (OLCF)
 
-**Row automatically selects from the following partitions on [Andes]:
+**Row** automatically selects from the following partitions on [Andes]:
 * `batch`
 
 > Note: Andes has no shared partition. All jobs must use 32 CPUs per node.
@@ -44,7 +44,7 @@ allows full-node jobs and does not incur extra charges.
 
 ## Frontier (OLCF)
 
-**Row automatically selects from the following partitions on [Frontier]:
+**Row** automatically selects from the following partitions on [Frontier]:
 * `batch`
 
 > Note: Frontier has no shared partition. All jobs must use 8 GPUs per node.

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -36,7 +36,7 @@ impl BuiltIn for launcher::Configuration {
                 executable: Some("srun".into()),
                 processes: Some("--ntasks=".into()),
                 threads_per_process: Some("--cpus-per-task=".into()),
-                gpus_per_process: Some("--gpus-per-task=".into()),
+                gpus_per_process: Some("--tres-per-task=gres/gpu:".into()),
             },
         );
 
@@ -46,7 +46,7 @@ impl BuiltIn for launcher::Configuration {
                 executable: Some("srun --mpi=pmi2".into()),
                 processes: Some("--ntasks=".into()),
                 threads_per_process: Some("--cpus-per-task=".into()),
-                gpus_per_process: Some("--gpus-per-task=".into()),
+                gpus_per_process: Some("--tres-per-task=gres/gpu:".into()),
             },
         );
 

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -239,13 +239,13 @@ fn greatlakes() -> Cluster {
                 name: "gpu_mig40,gpu".into(),
                 minimum_gpus_per_job: Some(1),
                 maximum_gpus_per_job: Some(1),
-                memory_per_cpu: Some("60G".into()),
+                memory_per_gpu: Some("60G".into()),
                 ..Partition::default()
             },
             Partition {
                 name: "gpu".into(),
                 minimum_gpus_per_job: Some(1),
-                memory_per_cpu: Some("60G".into()),
+                memory_per_gpu: Some("60G".into()),
                 // cannot set gpus_per_node, the partition is heterogeneous
                 ..Partition::default()
             },
@@ -253,14 +253,14 @@ fn greatlakes() -> Cluster {
             Partition {
                 name: "gpu_mig40".into(),
                 minimum_gpus_per_job: Some(1),
-                memory_per_cpu: Some("125G".into()),
+                memory_per_gpu: Some("125G".into()),
                 prevent_auto_select: true,
                 ..Partition::default()
             },
             Partition {
                 name: "spgpu".into(),
                 minimum_gpus_per_job: Some(1),
-                memory_per_cpu: Some("47000M".into()),
+                memory_per_gpu: Some("47000M".into()),
                 prevent_auto_select: true,
                 ..Partition::default()
             },

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -311,11 +311,11 @@ mod tests {
         };
         assert_eq!(
             mpi.prefix(&all, 11),
-            "srun --ntasks=66 --cpus-per-task=3 --gpus-per-task=8 "
+            "srun --ntasks=66 --cpus-per-task=3 --tres-per-task=gres/gpu:8 "
         );
         assert_eq!(
             mpi.prefix(&all, 1),
-            "srun --ntasks=6 --cpus-per-task=3 --gpus-per-task=8 "
+            "srun --ntasks=6 --cpus-per-task=3 --tres-per-task=gres/gpu:8 "
         );
     }
 

--- a/src/scheduler/bash.rs
+++ b/src/scheduler/bash.rs
@@ -458,7 +458,7 @@ mod tests {
         println!("{script}");
 
         assert!(script.contains(
-            "srun --ntasks=6 --cpus-per-task=4 --gpus-per-task=1 command \"${directories[@]}\""
+            "srun --ntasks=6 --cpus-per-task=4 --tres-per-task=gres/gpu:1 command \"${directories[@]}\""
         ));
     }
 


### PR DESCRIPTION
## Description

<!-- Describe your changes. -->
* Fix `--mem-per-gpu` on Great Lakes.
* Use `--tres-per-task=gpu:` instead of `--gpus-per-task=`


## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Allow users to submit GPU jobs with row.

## How has this been tested?

<!--- Please describe how you tested your changes. -->
`validate.py` tests pass on:
- [x] Great Lakes
- [x] Delta
- [x] Anvil
- [x] Andes
- [x] Frontier

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/row/blob/trunk/doc/src/developers/contributing.md).
- [x] I agree with the terms of the [**Row Contributor Agreement**](https://github.com/glotzerlab/row/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/src/contributors.md`) in the pull request source branch.
- [x] I have added a change log entry to `doc/src/release-notes.md`.
