### PR TITLE
Employ short circuit logic in `group.include.all`.

### DIFF
--- a/doc/src/release-notes.md
+++ b/doc/src/release-notes.md
@@ -18,6 +18,7 @@
 * `clean` now cleans all caches by default.
 * Submit jobs with `--constraint="scratch"` by default on Delta.
 * Submit jobs with `--constraint="nvme"` by default on Frontier.
+* `group.include.all` now employs short circuit evaluation.
 
 *Fixed:*
 

--- a/doc/src/workflow/action/group.md
+++ b/doc/src/workflow/action/group.md
@@ -23,15 +23,18 @@ groups of directories included in a given action.
 ## include
 
 `action.group.include`: **array** of **tables** - Define a set of selectors, *any* of
-which may be true for a directory to be included in this group.
+which may be `true` for a directory to be included in this group.
 
 Each selector is a **table** with only one of the following keys:
 * `condition`: An array of three elements: The *JSON pointer*, *the operator*, and the
   *operand*. The [JSON pointer](../../guide/concepts/json-pointers.md) references a
   specific portion of the directory's value. The operator may be `"<"`, `"<="`,
-  `"=="`, `">="`, or `">"`.
-* `all`: Array of conditions (see above). All conditions must be true for this selector
-  to be true.
+  `"=="`, `">="`, or `">"`. Both operands **must** have the same data type. The element
+  referenced by each JSON pointer must be present in the value of **every** directory.
+* `all`: Array of conditions (see above). All conditions must be `true` for this selector
+  to be `true`. `all` is evaluated with short-circuit logic. When an element in `all`
+  evaluates to `false`, the JSON pointers in the remaining elements are not evaluated
+  and are not required to be present.
 
 For example, select all directories where a value is in the given range:
 ```toml
@@ -54,10 +57,7 @@ Compare by array:
 condition = ["/array", "==", [1, "string", 14.0]
 ```
 
-Both operands **must** have the same data type. The element referenced by JSON pointer
-must be present in the value of **every** directory.
 
-When you omit `include`, **row** includes **all** directories in the workspace.
 
 > Note: **Row** compares arrays *lexicographically*.
 
@@ -65,6 +65,8 @@ When you omit `include`, **row** includes **all** directories in the workspace.
 JSON Objects (also known as maps or dictionaries) are not comparable. You must use
 pointers to specific keys in objects.
 </div>
+
+When you omit `include`, **row** includes **all** directories in the workspace.
 
 ## sort_by
 
@@ -122,7 +124,7 @@ would split into the groups:
 
 When omitted, there is no maximum group size.
 
-When `maximum_size` is set **and** `split_by_sort_key` is `true`, **row** first splits
+When both `maximum_size` **and** `split_by_sort_key` are `true`, **row** first splits
 by the sort key, then splits the resulting groups according to `maximum_size`.
 
 ## submit_whole

--- a/doc/src/workflow/action/group.md
+++ b/doc/src/workflow/action/group.md
@@ -57,8 +57,6 @@ Compare by array:
 condition = ["/array", "==", [1, "string", 14.0]
 ```
 
-
-
 > Note: **Row** compares arrays *lexicographically*.
 
 <div class="warning">

--- a/src/project.rs
+++ b/src/project.rs
@@ -211,7 +211,7 @@ impl Project {
                                         Error::JSONPointerNotFound(name.clone(), include.clone())
                                     })?;
 
-                                    if expr::evaluate_json_comparison(comparison, actual, expected)
+                                    if !expr::evaluate_json_comparison(comparison, actual, expected)
                                         .ok_or_else(|| {
                                             Error::CannotCompareInclude(
                                                 actual.clone(),
@@ -220,8 +220,9 @@ impl Project {
                                             )
                                         })?
                                     {
-                                        matches += 1;
+                                        break;
                                     }
+                                    matches += 1;
                                 }
                                 Ok(matches == conditions.len())
                             }


### PR DESCRIPTION
## Description

<!-- Describe your changes. -->
Stop evaluating `group.include.all` conditions after the first false.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Allow more flexible use of conditions in workspaces. I have a workspace where all directories have a `/subproject` value - but not all have a `/pressure`. The following condition is well-defined as long as all `patchy_particle_pressure` directories do have `/pressure`.

```toml
[[action.group.include]]
all = [
    [
    '/subproject',
    '==',
    'patchy_particle_pressure',
],
    [
    '/pressure',
    '>',
    0,
],
```

## How has this been tested?

<!--- Please describe how you tested your changes. -->
Tested locally with `hoomd-validation`.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/row/blob/trunk/doc/src/developers/contributing.md).
- [x] I agree with the terms of the [**Row Contributor Agreement**](https://github.com/glotzerlab/row/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/src/contributors.md`) in the pull request source branch.
- [x] I have added a change log entry to `doc/src/release-notes.md`.
