### PR TITLE
Use lychee instead of mdbook-linkcheck.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -120,15 +120,16 @@ jobs:
     - name: Build documentation
       run: mdbook build doc
       env:
-        RUST_LOG: "mdbook=info,linkcheck=warn,reqwest=debug"
+        RUST_LOG: "mdbook=info"
     - name: Check links
       uses: lycheeverse/lychee-action@2b973e86fc7b1f6b36a93795fe2c9c6ae1118621  # v1.10.0
       with:
         args: -n
               --exclude https://glotzerlab.engin.umich.edu
+              --exclude 'https://github.com/glotzerlab/row/edit.*'
               --exclude doi.org
-              './**/*.md' './**/*.html'
-              -v
+              './**/*.md'
+              './**/*.html'
         fail: true
 
   check_licenses:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -117,15 +117,27 @@ jobs:
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Set up mdbook
       uses: glotzerlab/workflows/setup-mdbook@ea2e25d07af862a1c696a932c2bd6b242d142049 # 0.2.0
-    - name: Add linkcheck configuration
-      run: |
-        echo -e "[output.linkcheck]\nfollow-web-links=true" >> doc/book.toml
-        cat doc/book.toml
     - name: Build documentation
       run: mdbook build doc
       env:
         RUST_LOG: "mdbook=info,linkcheck=warn,reqwest=debug"
-    - name: Set up mdbook
+    - name: Check links
+      uses: lycheeverse/lychee-action@2b973e86fc7b1f6b36a93795fe2c9c6ae1118621  # v1.10.0
+      with:
+        args: -n
+              --exclude https://glotzerlab.engin.umich.edu
+              --exclude doi.org
+              './**/*.md' './**/*.html'
+              -v
+        fail: true
+
+  check_licenses:
+    name: Check licenses
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+    - name: Set up cargo-bundle-licenses
       uses: glotzerlab/workflows/setup-cargo-bundle-licenses@ea2e25d07af862a1c696a932c2bd6b242d142049 # 0.2.0
     - name: Check bundled licenses
       run: cargo bundle-licenses --format yaml --output CI.yaml --previous THIRDPARTY.yaml --check-previous
@@ -133,7 +145,7 @@ jobs:
   tests_complete:
     name: All tests
     if: always()
-    needs: [unit_test, execute_tutorials, build_documentation]
+    needs: [unit_test, execute_tutorials, build_documentation,check_licenses]
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Description

<!-- Describe your changes. -->
Switch from mdbook-linkcheck to lychee.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
lychee has more features than mdbook-linkcheck (i.e. it can check the README) and is more actively maintained.

## How has this been tested?

<!--- Please describe how you tested your changes. -->
CI checks in this pull request.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/row/blob/trunk/doc/src/developers/contributing.md).
- [x] I agree with the terms of the [**Row Contributor Agreement**](https://github.com/glotzerlab/row/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/src/contributors.md`) in the pull request source branch.

