### PR TITLE
Update docs for delta account specification

### DIFF
--- a/doc/src/clusters/built-in.md
+++ b/doc/src/clusters/built-in.md
@@ -34,7 +34,8 @@ chooses the largest amount of memory available per core by default.
 * `cpu`
 * `gpuA100x4`
 
-For autoselection, set the `account` key to the prefix of your account (e.g. `xxxx-delta` for an account `xxxx-delta-gpu`). Other partitions may be selected manually.
+
+{{#include ../guide/howto/account.md:23:25}}
 
 [Delta] jobs default to a small amount of memory per core. **Row** inserts
 `--mem-per-cpu` or `--mem-per-gpu` to select the maximum amount of memory possible that

--- a/doc/src/clusters/built-in.md
+++ b/doc/src/clusters/built-in.md
@@ -35,7 +35,7 @@ chooses the largest amount of memory available per core by default.
 * `gpuA100x4`
 
 
-{{#include ../guide/howto/account.md:23:25}}
+{{#include ../guide/howto/account.md:delta}}
 
 [Delta] jobs default to a small amount of memory per core. **Row** inserts
 `--mem-per-cpu` or `--mem-per-gpu` to select the maximum amount of memory possible that

--- a/doc/src/clusters/built-in.md
+++ b/doc/src/clusters/built-in.md
@@ -34,7 +34,7 @@ chooses the largest amount of memory available per core by default.
 * `cpu`
 * `gpuA100x4`
 
-Other partitions may be selected manually.
+For autoselection, set the `account` key to the prefix of your account (e.g. `xxxx-delta` for an account `xxxx-delta-gpu`). Other partitions may be selected manually.
 
 [Delta] jobs default to a small amount of memory per core. **Row** inserts
 `--mem-per-cpu` or `--mem-per-gpu` to select the maximum amount of memory possible that

--- a/doc/src/guide/howto/account.md
+++ b/doc/src/guide/howto/account.md
@@ -20,6 +20,8 @@ submit_options.cluster1.account = "alternate-account"
 # Will use the "alternate-account" on cluster1 and "cluster2-account" on cluster2.
 ```
 
+<!-- ANCHOR: delta -->
 > Note: NCSA Delta assigns `<prefix>-cpu` and `<prefix>-gpu` accounts. Set
 > `submit_options.delta.account = "<prefix>"`. **Row** will automatically append the
 > `-cpu` or `-gpu` when submitting to the CPU or GPU partitions respectively.
+<!-- ANCHOR_END: delta -->


### PR DESCRIPTION
## Description

Accounts on delta are automatically suffixed with `-cpu` or `-gpu`. The documentation has been updated to reflect this by indicating only the account prefix must be supplied.

I'm not sure if this is the best way to document this, but Maria and I encountered (minor) confusion due to this behavior.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/row/blob/trunk/doc/src/developers/contributing.md).
- [x] I agree with the terms of the [**Row Contributor Agreement**](https://github.com/glotzerlab/row/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/src/contributors.md`) in the pull request source branch.
- [ ] I have added a change log entry to `doc/src/release-notes.md`.
