### PR TITLE
Add `workspace_path` and JSON pointer command template parameters.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,9 +784,11 @@ dependencies = [
  "path-absolutize",
  "postcard",
  "predicates",
+ "regex",
  "serde",
  "serde_json",
  "serial_test",
+ "shell-quote",
  "signal-hook",
  "speedate",
  "thiserror",
@@ -915,6 +917,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "shell-quote"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae4c63bdcc11eea49b562941b914d5ac30d42cad982e3f6e846a513ee6a3ce7e"
 
 [[package]]
 name = "signal-hook"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,10 @@ memchr = "2.7.4"
 nix = { version = "0.29.0", features = ["signal"] }
 path-absolutize = "3.1.1"
 postcard = { version = "1.0.10", default-features = false, features = ["use-std"] }
+regex = "1.11.0"
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.128"
+shell-quote = { version = "0.7.1", default-features = false, features = ["bash"] }
 signal-hook = { version = "0.3.17", default-features = false }
 speedate = "0.14.4"
 thiserror = "1.0.64"

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -293,5 +293,3 @@ status may take a long time, so it should display a progress bar.
 - **whole group**: A **submission group** that is identical to the **group** found
   without applying the additional submission filters.
 - **workspace**: The location on the file system that contains **directories**.
-
-# TODO: logo

--- a/THIRDPARTY.yaml
+++ b/THIRDPARTY.yaml
@@ -7064,6 +7064,215 @@ third_party_libraries:
          See the License for the specific language governing permissions and
          limitations under the License.
 
+- package_name: shell-quote
+  package_version: 0.7.1
+  repository: https://github.com/allenap/shell-quote
+  license: Apache-2.0
+  licenses:
+  - license: Apache-2.0
+    text: |2
+
+                                       Apache License
+                                 Version 2.0, January 2004
+                              http://www.apache.org/licenses/
+
+         TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+         1. Definitions.
+
+            "License" shall mean the terms and conditions for use, reproduction,
+            and distribution as defined by Sections 1 through 9 of this document.
+
+            "Licensor" shall mean the copyright owner or entity authorized by
+            the copyright owner that is granting the License.
+
+            "Legal Entity" shall mean the union of the acting entity and all
+            other entities that control, are controlled by, or are under common
+            control with that entity. For the purposes of this definition,
+            "control" means (i) the power, direct or indirect, to cause the
+            direction or management of such entity, whether by contract or
+            otherwise, or (ii) ownership of fifty percent (50%) or more of the
+            outstanding shares, or (iii) beneficial ownership of such entity.
+
+            "You" (or "Your") shall mean an individual or Legal Entity
+            exercising permissions granted by this License.
+
+            "Source" form shall mean the preferred form for making modifications,
+            including but not limited to software source code, documentation
+            source, and configuration files.
+
+            "Object" form shall mean any form resulting from mechanical
+            transformation or translation of a Source form, including but
+            not limited to compiled object code, generated documentation,
+            and conversions to other media types.
+
+            "Work" shall mean the work of authorship, whether in Source or
+            Object form, made available under the License, as indicated by a
+            copyright notice that is included in or attached to the work
+            (an example is provided in the Appendix below).
+
+            "Derivative Works" shall mean any work, whether in Source or Object
+            form, that is based on (or derived from) the Work and for which the
+            editorial revisions, annotations, elaborations, or other modifications
+            represent, as a whole, an original work of authorship. For the purposes
+            of this License, Derivative Works shall not include works that remain
+            separable from, or merely link (or bind by name) to the interfaces of,
+            the Work and Derivative Works thereof.
+
+            "Contribution" shall mean any work of authorship, including
+            the original version of the Work and any modifications or additions
+            to that Work or Derivative Works thereof, that is intentionally
+            submitted to Licensor for inclusion in the Work by the copyright owner
+            or by an individual or Legal Entity authorized to submit on behalf of
+            the copyright owner. For the purposes of this definition, "submitted"
+            means any form of electronic, verbal, or written communication sent
+            to the Licensor or its representatives, including but not limited to
+            communication on electronic mailing lists, source code control systems,
+            and issue tracking systems that are managed by, or on behalf of, the
+            Licensor for the purpose of discussing and improving the Work, but
+            excluding communication that is conspicuously marked or otherwise
+            designated in writing by the copyright owner as "Not a Contribution."
+
+            "Contributor" shall mean Licensor and any individual or Legal Entity
+            on behalf of whom a Contribution has been received by Licensor and
+            subsequently incorporated within the Work.
+
+         2. Grant of Copyright License. Subject to the terms and conditions of
+            this License, each Contributor hereby grants to You a perpetual,
+            worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+            copyright license to reproduce, prepare Derivative Works of,
+            publicly display, publicly perform, sublicense, and distribute the
+            Work and such Derivative Works in Source or Object form.
+
+         3. Grant of Patent License. Subject to the terms and conditions of
+            this License, each Contributor hereby grants to You a perpetual,
+            worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+            (except as stated in this section) patent license to make, have made,
+            use, offer to sell, sell, import, and otherwise transfer the Work,
+            where such license applies only to those patent claims licensable
+            by such Contributor that are necessarily infringed by their
+            Contribution(s) alone or by combination of their Contribution(s)
+            with the Work to which such Contribution(s) was submitted. If You
+            institute patent litigation against any entity (including a
+            cross-claim or counterclaim in a lawsuit) alleging that the Work
+            or a Contribution incorporated within the Work constitutes direct
+            or contributory patent infringement, then any patent licenses
+            granted to You under this License for that Work shall terminate
+            as of the date such litigation is filed.
+
+         4. Redistribution. You may reproduce and distribute copies of the
+            Work or Derivative Works thereof in any medium, with or without
+            modifications, and in Source or Object form, provided that You
+            meet the following conditions:
+
+            (a) You must give any other recipients of the Work or
+                Derivative Works a copy of this License; and
+
+            (b) You must cause any modified files to carry prominent notices
+                stating that You changed the files; and
+
+            (c) You must retain, in the Source form of any Derivative Works
+                that You distribute, all copyright, patent, trademark, and
+                attribution notices from the Source form of the Work,
+                excluding those notices that do not pertain to any part of
+                the Derivative Works; and
+
+            (d) If the Work includes a "NOTICE" text file as part of its
+                distribution, then any Derivative Works that You distribute must
+                include a readable copy of the attribution notices contained
+                within such NOTICE file, excluding those notices that do not
+                pertain to any part of the Derivative Works, in at least one
+                of the following places: within a NOTICE text file distributed
+                as part of the Derivative Works; within the Source form or
+                documentation, if provided along with the Derivative Works; or,
+                within a display generated by the Derivative Works, if and
+                wherever such third-party notices normally appear. The contents
+                of the NOTICE file are for informational purposes only and
+                do not modify the License. You may add Your own attribution
+                notices within Derivative Works that You distribute, alongside
+                or as an addendum to the NOTICE text from the Work, provided
+                that such additional attribution notices cannot be construed
+                as modifying the License.
+
+            You may add Your own copyright statement to Your modifications and
+            may provide additional or different license terms and conditions
+            for use, reproduction, or distribution of Your modifications, or
+            for any such Derivative Works as a whole, provided Your use,
+            reproduction, and distribution of the Work otherwise complies with
+            the conditions stated in this License.
+
+         5. Submission of Contributions. Unless You explicitly state otherwise,
+            any Contribution intentionally submitted for inclusion in the Work
+            by You to the Licensor shall be under the terms and conditions of
+            this License, without any additional terms or conditions.
+            Notwithstanding the above, nothing herein shall supersede or modify
+            the terms of any separate license agreement you may have executed
+            with Licensor regarding such Contributions.
+
+         6. Trademarks. This License does not grant permission to use the trade
+            names, trademarks, service marks, or product names of the Licensor,
+            except as required for reasonable and customary use in describing the
+            origin of the Work and reproducing the content of the NOTICE file.
+
+         7. Disclaimer of Warranty. Unless required by applicable law or
+            agreed to in writing, Licensor provides the Work (and each
+            Contributor provides its Contributions) on an "AS IS" BASIS,
+            WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+            implied, including, without limitation, any warranties or conditions
+            of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+            PARTICULAR PURPOSE. You are solely responsible for determining the
+            appropriateness of using or redistributing the Work and assume any
+            risks associated with Your exercise of permissions under this License.
+
+         8. Limitation of Liability. In no event and under no legal theory,
+            whether in tort (including negligence), contract, or otherwise,
+            unless required by applicable law (such as deliberate and grossly
+            negligent acts) or agreed to in writing, shall any Contributor be
+            liable to You for damages, including any direct, indirect, special,
+            incidental, or consequential damages of any character arising as a
+            result of this License or out of the use or inability to use the
+            Work (including but not limited to damages for loss of goodwill,
+            work stoppage, computer failure or malfunction, or any and all
+            other commercial damages or losses), even if such Contributor
+            has been advised of the possibility of such damages.
+
+         9. Accepting Warranty or Additional Liability. While redistributing
+            the Work or Derivative Works thereof, You may choose to offer,
+            and charge a fee for, acceptance of support, warranty, indemnity,
+            or other liability obligations and/or rights consistent with this
+            License. However, in accepting such obligations, You may act only
+            on Your own behalf and on Your sole responsibility, not on behalf
+            of any other Contributor, and only if You agree to indemnify,
+            defend, and hold each Contributor harmless for any liability
+            incurred by, or claims asserted against, such Contributor by reason
+            of your accepting any such warranty or additional liability.
+
+         END OF TERMS AND CONDITIONS
+
+         APPENDIX: How to apply the Apache License to your work.
+
+            To apply the Apache License to your work, attach the following
+            boilerplate notice, with the fields enclosed by brackets "[]"
+            replaced with your own identifying information. (Don't include
+            the brackets!)  The text should be enclosed in the appropriate
+            comment syntax for the file format. We also recommend that a
+            file or class name and description of purpose be included on the
+            same "printed page" as the copyright notice for easier
+            identification within third-party archives.
+
+         Copyright [yyyy] [name of copyright owner]
+
+         Licensed under the Apache License, Version 2.0 (the "License");
+         you may not use this file except in compliance with the License.
+         You may obtain a copy of the License at
+
+             http://www.apache.org/licenses/LICENSE-2.0
+
+         Unless required by applicable law or agreed to in writing, software
+         distributed under the License is distributed on an "AS IS" BASIS,
+         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+         See the License for the specific language governing permissions and
+         limitations under the License.
 - package_name: signal-hook
   package_version: 0.3.17
   repository: https://github.com/vorner/signal-hook

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -8,6 +8,7 @@
 - [Tutorial](guide/tutorial/index.md)
   - [Hello, workflow!](guide/tutorial/hello.md)
   - [Managing multiple actions](guide/tutorial/multiple.md)
+  - [Assigning values to directories](guide/tutorial/value.md)
   - [Grouping directories](guide/tutorial/group.md)
   - [Submitting jobs manually](guide/tutorial/scheduler.md)
   - [Requesting resources with row](guide/tutorial/resources.md)

--- a/doc/src/env.md
+++ b/doc/src/env.md
@@ -6,6 +6,7 @@
 
 | Environment variable | Value |
 |----------------------|-------|
+| `ACTION_WORKSPACE_PATH` | Path to the workspace, relative to the path containing `workflow.toml`. |
 | `ACTION_CLUSTER` | Name of the cluster the action is executing on. |
 | `ACTION_NAME` | The name of the action that is executing. |
 | `ACTION_PROCESSES` | The total number of processes that this action uses. |

--- a/doc/src/guide/tutorial/.gitignore
+++ b/doc/src/guide/tutorial/.gitignore
@@ -1,2 +1,3 @@
 /hello-workflow
 /group-workflow
+/value-workflow

--- a/doc/src/guide/tutorial/group-workflow1.toml
+++ b/doc/src/guide/tutorial/group-workflow1.toml
@@ -1,2 +1,0 @@
-[workspace]
-value_file = "value.json"

--- a/doc/src/guide/tutorial/group.md
+++ b/doc/src/guide/tutorial/group.md
@@ -2,49 +2,30 @@
 
 ## Overview
 
-This section shows how you can assign a **value** to each directory and use that
-**value** to form **groups** of directories. Each **job** executes an action's command
-on a **group** of directories.
+This section shows how you can use **values** to form **groups** of directories. Each
+**job** executes an action's command on a **group** of directories.
 
-## Directory values
+## Initialize a workspace with values
 
-So far, this tutorial has demonstrated small toy examples. In practice, any workflow
-that you need to execute on a cluster likely has hundreds or thousands of directories -
-each with different parameters. You could try to encode these parameters into the
-directory names, but *please don't* - it quickly becomes unmanageable. Instead, you
-should include a [JSON](https://www.json.org) file in each directory that identifies
-its **value**.
+To demonstrate the capabilities of **groups**, create a workspace with multiple types of
+values. The following script follows the same process used in the previous section:
 
-> Note: For pedagogical reasons, this next code block manually creates directory names
-> and value files. In practice, you will likely find [signac](../python/signac.md) more
-> convenient to work with - it will create the JSON files and directories for you with
-> a cleaner syntax. This tutorial will cover **row** ↔ **signac** interoperation in a
-> later section.
-
-Create a new workflow project and place JSON files in each directory:
 ```bash
 {{#include group.sh:init}}
 ```
-The JSON files must all have the same name. Instruct **row** to read these files
-with the `workspace.value_file` key in `workflow.toml`:
 
-```toml
-{{#include group-workflow1.toml}}
-```
+As mentioned previously, `echo` is used here to create a _minimal_ script that you can
+execute to follow along. For any serious production work you will likely find [signac]
+more convenient to work with.
 
-Once you create a directory with a **value** file, that value **MUST NOT CHANGE**. Think
-of it this way: The results of your computations (the final contents of the directory)
-are a mathematical *function* of the **value**. When you want to know the results for
-another value, *create a new directory with that value!*. **row** assumes this data
-model and [caches](../concepts/cache.md) all value files so that it does not need to
-read thousands of files every time you execute a **row** command.
+[signac]: ../python/signac.md
 
 ## Grouping by value
 
-Now that your workspace directories have **values**, you can use those to form
-**groups**. Every action in your workflow operates on **groups**. Add entries to the
-`action.group.include` array in an action to select which directories to include by
-**value**. To see how this works, replace the contents of `workflow.toml` with:
+You can use **values** those to form **groups** of **directories**. Every action in
+your workflow operates on **groups**. Add entries to the `action.group.include` array
+in an action to select which directories to include by **value**. To see how this works,
+replace the contents of `workflow.toml` with:
 
 ```toml
 {{#include group-workflow2.toml}}

--- a/doc/src/guide/tutorial/value-workflow.toml
+++ b/doc/src/guide/tutorial/value-workflow.toml
@@ -1,0 +1,10 @@
+# ANCHOR: workspace
+[workspace]
+value_file = "value.json"
+# ANCHOR_END: workspace
+
+# ANCHOR: action
+[[action]]
+name = "show"
+command = 'echo {directory}, seed: {/seed}, pressure: {/pressure}'
+# ANCHOR_END: action

--- a/doc/src/guide/tutorial/value.md
+++ b/doc/src/guide/tutorial/value.md
@@ -49,7 +49,7 @@ Now that your workspace directories have **values**, you can pass them to your
 commands using **template parameters**. You have already used one template parameter:
 `{directory}`. Each **template parameter** name is surrounded by curly braces.
 
-[JSON] files store a (possibly nested) key/value mapping. Use a [*JSON pointer*] to 
+[JSON] files store a (possibly nested) key/value mapping. Use a [*JSON pointer*] to
 reference a portion of the directory's value by placing the [*JSON pointer*] between
 curly braces. Add the following section to `workflow.toml` that uses **template
 parameters** in the action's `command`:

--- a/doc/src/guide/tutorial/value.md
+++ b/doc/src/guide/tutorial/value.md
@@ -1,0 +1,85 @@
+# Assigning values to directories
+
+## Overview
+
+This section shows how you can assign a **value** to each directory and use a command
+**template** to access portions of that value when submitting **actions**.
+
+## Directory values
+
+So far, this tutorial has demonstrated small toy examples. In practice, any workflow
+that you need to execute on a cluster likely has hundreds or thousands of directories -
+each with different parameters. You could try to encode these parameters into the
+directory names, but *please don't* - it quickly becomes unmanageable. Instead, you
+should include a [JSON] file in each directory that identifies its **value**.
+
+[JSON]: https://www.json.org
+
+> Note: For pedagogical reasons, this next code block manually creates directory names
+> and value files. In practice, you will likely find [signac] more
+> convenient to work with - it will create the JSON files and directories for you with
+> a cleaner syntax. This tutorial will cover **row** ↔ **signac** interoperation in a
+> later section.
+
+[signac]: ../python/signac.md
+
+Create a new workflow project and place JSON files in each directory:
+```bash
+{{#include value.sh:init}}
+```
+The JSON files must all have the same name. Instruct **row** to read these files
+with the `workspace.value_file` key in `workflow.toml`:
+
+```toml
+{{#include value-workflow.toml:workspace}}
+```
+
+Once you create a directory with a **value** file, that value **MUST NOT CHANGE**. Think
+of it this way: The results of your computations (the final contents of the directory)
+are a mathematical *function* of the **value**. When you want to know the results for
+another value, *create a new directory with that value!*. **row** assumes this data
+model and [caches] all value files so that it does not need to read thousands of files
+every time you execute a **row** command.
+
+[caches]: ../concepts/cache.md
+
+## Passing values to commands
+
+Now that your workspace directories have **values**, you can pass them to your
+commands using **template parameters**. You have already used one template parameter:
+`{directory}`. Each **template parameter** name is surrounded by curly braces.
+
+[JSON] files store a (possibly nested) key/value mapping. Use a [*JSON pointer*] to 
+reference a portion of the directory's value by placing the [*JSON pointer*] between
+curly braces. Add the following section to `workflow.toml` that uses **template
+parameters** in the action's `command`:
+
+```toml
+{{#include value-workflow.toml:action}}
+```
+
+[*JSON pointer*]: ../concepts/json-pointers.md
+
+Execute the following (and answer yes at the prompt):
+```bash
+{{#include value.sh:submit}}
+```
+
+You should see:
+```plaintext
+directory1, seed: 0, pressure: 1.5
+directory2, seed: 1, pressure: 1.5
+directory3, seed: 0, pressure: 2.1
+directory4, seed: 1, pressure: 2.1
+```
+
+Consider how you would use this for your own workflows. For example:
+```toml
+command = './application -s {/seed} -p {/pressure} -o workspace/{directory}/out'
+```
+
+# Next steps
+
+You have now assigned **values** to each **directory** in the workspace and learned
+how you can use these **values** with **template parameters** in the **command**. The
+next section will show you how to use **values** to form **groups**.

--- a/doc/src/guide/tutorial/value.sh
+++ b/doc/src/guide/tutorial/value.sh
@@ -1,0 +1,19 @@
+
+# ANCHOR: init
+row init value-workflow
+cd value-workflow/workspace
+
+mkdir directory1 && echo '{"seed": 0, "pressure": 1.5}' > directory1/value.json
+mkdir directory2 && echo '{"seed": 1, "pressure": 1.5}' > directory2/value.json
+mkdir directory3 && echo '{"seed": 0, "pressure": 2.1}' > directory3/value.json
+mkdir directory4 && echo '{"seed": 1, "pressure": 2.1}' > directory4/value.json
+
+# ANCHOR_END: init
+
+cd ..
+
+cp ../value-workflow.toml workflow.toml
+
+# ANCHOR: submit
+row submit
+# ANCHOR_END: submit

--- a/doc/src/release-notes.md
+++ b/doc/src/release-notes.md
@@ -1,5 +1,23 @@
 # Release notes
 
+## 0.4.0 (not yet released)
+
+*Highlights:*
+
+*Added:*
+
+* In job scripts, set the environment variable `ACTION_WORKSPACE_PATH` to the _relative_
+  path to the current workspace.
+* `{workspace_path}` template parameter in `action.command` - replaced with the
+  _relative_ path to the current workspace.
+* `{/JSON pointer}` template parameter in `action.command` - replaced with the portion
+  of the directory's value referenced by the given JSON pointer.
+
+*Fixed:*
+
+* All user-provided content (directories, action names, cluster names, and values) are
+  properly escaped in the bash script output.
+
 ## 0.3.1 (2024-10-04)
 
 *Changed:*

--- a/doc/src/workflow/action/index.md
+++ b/doc/src/workflow/action/index.md
@@ -65,6 +65,27 @@ or chain the steps with `&&`. For example:
 command = "echo Message && python action.py {directory}"
 ```
 
+### Template parameters
+
+`action.command` will expand any template parameter contained within curly braces:
+`{template_parameter}`.
+
+* `{directory}` and `{directories}` are described above.
+* `{workspace_path}` will be replaced with the _relative_ path from the project root
+  (the directory containing `workflow.toml`) to the currently selected workspace.
+* `{/JSON pointer}` will be replaced by a portion of the directory's value referenced
+  by the given [JSON pointer]. Must be used with `{directory}`.
+* `{}` will be replaced by the entire directory value formatted in JSON as a single
+  command line argument. Must be used with `{directory}`
+* All other template parameters are invalid.
+
+For example:
+```toml
+command = "application -p {/pressure} -s {/seed} -o {workspace_path}/{directory}/out"
+```
+
+[JSON pointer]: ../../guide/concepts/json-pointers.md
+
 ## launchers
 
 `action.launchers`: **array** of **strings** - The launchers to apply when executing a

--- a/src/cli/submit.rs
+++ b/src/cli/submit.rs
@@ -170,7 +170,12 @@ pub fn submit<W: Write>(
         info!("Execute without --dry-run to submit the following scripts...");
         for (index, (action, directories)) in action_directories.iter().enumerate() {
             info!("Script {}/{}:", index + 1, action_directories.len());
-            let script = scheduler.make_script(action, directories)?;
+            let script = scheduler.make_script(
+                action,
+                directories,
+                &project.workflow().workspace.path,
+                project.state().values(),
+            )?;
 
             write!(output, "{script}")?;
             output.flush()?;
@@ -264,6 +269,8 @@ pub fn submit<W: Write>(
             &project.workflow().root,
             action,
             directories,
+            &project.workflow().workspace.path,
+            project.state().values(),
             Arc::clone(&should_terminate),
         );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,6 +148,14 @@ pub enum Error {
     #[error("Duplicate actions '{0}' must have the same `previous_actions`.")]
     DuplicateActionsDifferentPreviousActions(String),
 
+    #[error(
+        r"Action '{0}' must use {{directory}} instead of {{directories}} with {{\JSON pointer}}."
+    )]
+    DirectoriesUsedWithJSONPointer(String),
+
+    #[error("Unable to parse template '{1}' for action '{0}'.")]
+    InvalidTemplate(String, String),
+
     // submission errors
     #[error("Error encountered while executing action '{0}': {1}.")]
     ExecuteAction(String, String),

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -4,7 +4,8 @@
 pub mod bash;
 pub mod slurm;
 
-use std::collections::HashSet;
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
@@ -14,44 +15,61 @@ use crate::Error;
 
 /// A `Scheduler` creates and submits job scripts.
 pub trait Scheduler {
-    /// Make a job script given an `Action` and a list of directories.
-    ///
-    /// Useful for showing the script that would be submitted to the user.
-    ///
-    /// # Returns
-    /// A `String` containing the job script.
-    ///
-    /// # Errors
-    /// Returns `Err<row::Error>` when the script cannot be created.
-    ///
-    fn make_script(&self, action: &Action, directories: &[PathBuf]) -> Result<String, Error>;
+    /** Make a job script given an `Action` and a list of directories.
 
-    /// Submit a job to the scheduler.
-    ///
-    /// # Arguments
-    /// * `workflow_root`: The working directory the action should be submitted from.
-    /// * `action`: The action to submit.
-    /// * `directories`: The directories to include in the submission.
-    /// * `should_terminate`: Set to true when the user terminates the process.
-    ///
-    /// # Returns
-    /// `Ok(job_id_option)` on success.
-    /// Schedulers that queue jobs should set `job_id_option = Some(job_id)`.
-    /// Schedulers that execute jobs immediately should set `job_id_option = None`.
-    ///
-    /// # Early termination.
-    /// Implementations should periodically check `should_terminate` and
-    /// exit early (if possible) with `Err(Error::Interrupted)` when set.
-    ///
-    /// # Errors
-    /// Returns `Err(row::Error)` on error, which may be due to a non-zero exit
-    /// status from the submission.
-    ///
+    # Arguments
+    * `action`: The action to submit.
+    * `directories`: The directories to include in the submission.
+    * `workspace_path`: The relative path to the workspace directory from the workflow root.
+    * `directory_values`: Maps directory names to JSON values.
+
+    `make_script` must use expand `{workspace_path`} and `{\JSON pointer}`
+    templates in the action's command.
+
+    # Returns
+    A `String` containing the job script.
+
+    # Errors
+    Returns `Err<row::Error>` when the script cannot be created.
+    */
+    fn make_script(
+        &self,
+        action: &Action,
+        directories: &[PathBuf],
+        workspace_path: &Path,
+        directory_values: &HashMap<PathBuf, Value>,
+    ) -> Result<String, Error>;
+
+    /** Submit a job to the scheduler.
+
+    # Arguments
+    * `workflow_root`: The working directory the action should be submitted from.
+    * `action`: The action to submit.
+    * `directories`: The directories to include in the submission.
+    * `workspace_path`: The relative path to the workspace directory from the workflow root.
+    * `directory_values`: Maps directory names to JSON values.
+    * `should_terminate`: Set to true when the user terminates the process.
+
+    # Returns
+    `Ok(job_id_option)` on success.
+    Schedulers that queue jobs should set `job_id_option = Some(job_id)`.
+    Schedulers that execute jobs immediately should set `job_id_option = None`.
+
+    # Early termination.
+    Implementations should periodically check `should_terminate` and
+    exit early (if possible) with `Err(Error::Interrupted)` when set.
+
+    # Errors
+    Returns `Err(row::Error)` on error, which may be due to a non-zero exit
+    status from the submission.
+    */
     fn submit(
         &self,
         workflow_root: &Path,
         action: &Action,
         directories: &[PathBuf],
+        workspace_path: &Path,
+        directory_values: &HashMap<PathBuf, Value>,
         should_terminate: Arc<AtomicBool>,
     ) -> Result<Option<u32>, Error>;
 

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -29,7 +29,7 @@ pub trait Scheduler {
     /// Submit a job to the scheduler.
     ///
     /// # Arguments
-    /// * `working_directory`: The working directory the action should be submitted from.
+    /// * `workflow_root`: The working directory the action should be submitted from.
     /// * `action`: The action to submit.
     /// * `directories`: The directories to include in the submission.
     /// * `should_terminate`: Set to true when the user terminates the process.
@@ -49,7 +49,7 @@ pub trait Scheduler {
     ///
     fn submit(
         &self,
-        working_directory: &Path,
+        workflow_root: &Path,
         action: &Action,
         directories: &[PathBuf],
         should_terminate: Arc<AtomicBool>,

--- a/src/scheduler/bash.rs
+++ b/src/scheduler/bash.rs
@@ -280,7 +280,6 @@ done
     */
     fn substitute(&self, command: &str, directory: &Path) -> Result<String, Error> {
         let replacement = |caps: &Captures| -> Result<String, Error> {
-            println!("Matching {}", &caps[0]);
             match &caps[0] {
                 "{workspace_path}" => Ok(shell_quote::Bash::quote(
                     self.workspace_path

--- a/src/scheduler/bash.rs
+++ b/src/scheduler/bash.rs
@@ -242,7 +242,7 @@ impl Scheduler for Bash {
 
     fn submit(
         &self,
-        working_directory: &Path,
+        workflow_root: &Path,
         action: &Action,
         directories: &[PathBuf],
         should_terminate: Arc<AtomicBool>,
@@ -252,7 +252,7 @@ impl Scheduler for Bash {
 
         let mut child = Command::new("bash")
             .stdin(Stdio::piped())
-            .current_dir(working_directory)
+            .current_dir(workflow_root)
             .spawn()
             .map_err(|e| Error::SpawnProcess("bash".into(), e))?;
 

--- a/src/scheduler/slurm.rs
+++ b/src/scheduler/slurm.rs
@@ -141,7 +141,7 @@ impl Scheduler for Slurm {
 
     fn submit(
         &self,
-        working_directory: &Path,
+        workflow_root: &Path,
         action: &Action,
         directories: &[PathBuf],
         should_terminate: Arc<AtomicBool>,
@@ -164,7 +164,7 @@ impl Scheduler for Slurm {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .arg("--parsable")
-            .current_dir(working_directory)
+            .current_dir(workflow_root)
             .spawn()
             .map_err(|e| Error::SpawnProcess("sbatch".into(), e))?;
 

--- a/src/scheduler/slurm.rs
+++ b/src/scheduler/slurm.rs
@@ -2,6 +2,7 @@
 // Part of row, released under the BSD 3-Clause License.
 
 use log::{debug, error, trace};
+use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
 use std::io::Write;
@@ -41,7 +42,13 @@ pub struct ActiveSlurmJobs {
 }
 
 impl Scheduler for Slurm {
-    fn make_script(&self, action: &Action, directories: &[PathBuf]) -> Result<String, Error> {
+    fn make_script(
+        &self,
+        action: &Action,
+        directories: &[PathBuf],
+        workspace_path: &Path,
+        directory_values: &HashMap<PathBuf, Value>,
+    ) -> Result<String, Error> {
         let mut preamble = String::with_capacity(512);
         let mut user_partition = &None;
 
@@ -134,9 +141,16 @@ impl Scheduler for Slurm {
             }
         }
 
-        BashScriptBuilder::new(&self.cluster.name, action, directories, &self.launchers)
-            .with_preamble(&preamble)
-            .build()
+        BashScriptBuilder::new(
+            &self.cluster.name,
+            action,
+            directories,
+            workspace_path,
+            directory_values,
+            &self.launchers,
+        )
+        .with_preamble(&preamble)
+        .build()
     }
 
     fn submit(
@@ -144,6 +158,8 @@ impl Scheduler for Slurm {
         workflow_root: &Path,
         action: &Action,
         directories: &[PathBuf],
+        workspace_path: &Path,
+        directory_values: &HashMap<PathBuf, Value>,
         should_terminate: Arc<AtomicBool>,
     ) -> Result<Option<u32>, Error> {
         debug!("Submtitting '{}' with sbatch.", action.name());
@@ -158,7 +174,7 @@ impl Scheduler for Slurm {
             return Err(Error::Interrupted);
         }
 
-        let script = self.make_script(action, directories)?;
+        let script = self.make_script(action, directories, workspace_path, directory_values)?;
 
         let mut child = Command::new("sbatch")
             .stdin(Stdio::piped())
@@ -316,7 +332,7 @@ mod tests {
     fn default() {
         let (action, directories, slurm) = setup();
         let script = slurm
-            .make_script(&action, &directories)
+            .make_script(&action, &directories, &PathBuf::default(), &HashMap::new())
             .expect("valid script");
         println!("{script}");
 
@@ -336,7 +352,7 @@ mod tests {
         slurm.cluster.submit_options = vec!["--option=value".to_string()];
 
         let script = slurm
-            .make_script(&action, &directories)
+            .make_script(&action, &directories, &PathBuf::default(), &HashMap::new())
             .expect("valid script");
         println!("{script}");
 
@@ -358,7 +374,7 @@ mod tests {
         action.resources.processes = Some(Processes::PerDirectory(3));
 
         let script = slurm
-            .make_script(&action, &directories)
+            .make_script(&action, &directories, &PathBuf::default(), &HashMap::new())
             .expect("valid script");
         println!("{script}");
 
@@ -379,7 +395,7 @@ mod tests {
         );
 
         let script = slurm
-            .make_script(&action, &directories)
+            .make_script(&action, &directories, &PathBuf::default(), &HashMap::new())
             .expect("valid script");
         println!("{script}");
 
@@ -400,7 +416,7 @@ mod tests {
         );
 
         let script = slurm
-            .make_script(&action, &directories)
+            .make_script(&action, &directories, &PathBuf::default(), &HashMap::new())
             .expect("valid script");
         println!("{script}");
 
@@ -416,7 +432,7 @@ mod tests {
         action.resources.threads_per_process = Some(5);
 
         let script = slurm
-            .make_script(&action, &directories)
+            .make_script(&action, &directories, &PathBuf::default(), &HashMap::new())
             .expect("valid script");
         println!("{script}");
 
@@ -431,7 +447,7 @@ mod tests {
         action.resources.gpus_per_process = Some(5);
 
         let script = slurm
-            .make_script(&action, &directories)
+            .make_script(&action, &directories, &PathBuf::default(), &HashMap::new())
             .expect("valid script");
         println!("{script}");
 
@@ -458,7 +474,7 @@ mod tests {
         let slurm = Slurm::new(cluster, launchers.by_cluster("cluster"));
 
         let script = slurm
-            .make_script(&action, &directories)
+            .make_script(&action, &directories, &PathBuf::default(), &HashMap::new())
             .expect("valid script");
         println!("{script}");
 
@@ -487,7 +503,7 @@ mod tests {
         action.resources.gpus_per_process = Some(1);
 
         let script = slurm
-            .make_script(&action, &directories)
+            .make_script(&action, &directories, &PathBuf::default(), &HashMap::new())
             .expect("valid script");
         println!("{script}");
 
@@ -516,7 +532,7 @@ mod tests {
         action.resources.processes = Some(Processes::PerSubmission(81));
 
         let script = slurm
-            .make_script(&action, &directories)
+            .make_script(&action, &directories, &PathBuf::default(), &HashMap::new())
             .expect("valid script");
         println!("{script}");
 
@@ -546,7 +562,7 @@ mod tests {
         action.resources.gpus_per_process = Some(1);
 
         let script = slurm
-            .make_script(&action, &directories)
+            .make_script(&action, &directories, &PathBuf::default(), &HashMap::new())
             .expect("valid script");
         println!("{script}");
 


### PR DESCRIPTION
## Description

<!-- Describe your changes. -->
Allow row to generate commands directly for command line applications. Also properly escape all user-provided strings that are placed in bash scripts.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Previously, users needed to write a wrapper script in Python that parsed the JSON file and then called `subprocess.run`.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #51

## How has this been tested?

<!--- Please describe how you tested your changes. -->
Extensive unit tests.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/row/blob/trunk/doc/src/developers/contributing.md).
- [x] I agree with the terms of the [**Row Contributor Agreement**](https://github.com/glotzerlab/row/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/src/contributors.md`) in the pull request source branch.
- [x] I have added a change log entry to `doc/src/release-notes.md`.
