### PR TITLE
Cast environment variables to integers

### DIFF
--- a/doc/src/contributors.md
+++ b/doc/src/contributors.md
@@ -7,3 +7,4 @@ The following people have contributed to the development of **row**:
 * Joseph Burkhart, University of Michigan
 * Kate Jensen, University of Michigan
 * Tim Moore, University of Michigan
+* Corwin Kerr, University of Michigan

--- a/doc/src/guide/concepts/hoomd-example.py
+++ b/doc/src/guide/concepts/hoomd-example.py
@@ -17,7 +17,7 @@ def action_implementation(job, communicator):
 
 def action(*jobs):
     """Execute actions on directories in parallel using HOOMD-blue."""
-    processes_per_directory = os.environ['ACTION_PROCESSES_PER_DIRECTORY']
+    processes_per_directory = int(os.environ['ACTION_PROCESSES_PER_DIRECTORY'])
     communicator = hoomd.communicator.Communicator(ranks_per_partition=processes_per_directory)
     action_implementation(jobs[communicator.partition], communicator)
     # ANCHOR_END: action

--- a/doc/src/guide/concepts/multiprocessing-example.py
+++ b/doc/src/guide/concepts/multiprocessing-example.py
@@ -15,7 +15,7 @@ def action_implementation(job):
 
 def action(*jobs):
     """Process any number of jobs in parallel with the multiprocessing package."""
-    processes = os.environ.get('ACTION_THREADS_PER_PROCESS', multiprocessing.cpu_count())
+    processes = int(os.environ.get('ACTION_THREADS_PER_PROCESS', multiprocessing.cpu_count()))
     if hasattr(os, 'sched_getaffinity'):
         processes = len(os.sched_getaffinity(0))
 

--- a/doc/src/release-notes.md
+++ b/doc/src/release-notes.md
@@ -19,6 +19,7 @@
   properly escaped in the bash script output.
 * Typographical errors in the documentation.
 * The documentation now builds correctly with mdbook 0.4.43.
+* Example code converts environment variables to ints where needed.
 
 ## 0.3.1 (2024-10-04)
 


### PR DESCRIPTION
## Description

Cast environment variables to integers in example code.

## Motivation and context

Ran into the undefined operator error in Communicator where it checks the following with `ranks_per_partition` as a string.

```python
if self.cpp_mpi_conf.getNRanksGlobal() % ranks_per_partition:
```

## How has this been tested?

I changed the code I copied which fixed the problem. I didn't test the change for getting `ACTION_THREADS_PER_PROCESS`

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/row/blob/trunk/doc/src/developers/contributing.md).
- [x] I agree with the terms of the [**Row Contributor Agreement**](https://github.com/glotzerlab/row/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/src/contributors.md`) in the pull request source branch.
- [x] I have added a change log entry to `doc/src/release-notes.md`.
