### PR TITLE
Validate that users request more than 0 resources.

### DIFF
--- a/doc/src/release-notes.md
+++ b/doc/src/release-notes.md
@@ -14,6 +14,7 @@ The subcommands `show directories`, `show jobs`, and `show status` now report
 
 * Writing tabular output with no rows now results in the output `No matches.`.
 * Build executables on Ubuntu 22.04.
+* Report an error when the workflow requests 0 processes, GPUs, or threads.
 
 ## 0.4.0 (2024-12-06)
 

--- a/doc/src/workflow/action/resources.md
+++ b/doc/src/workflow/action/resources.md
@@ -34,7 +34,8 @@ to perform computations. Use `per_directory` when your action parallelizes over 
 directories and therefore requires `processes.per_directory * num_directories` total
 processes.
 
-When omitted, `processes` defaults to `per_submission = 1`.
+When omitted, `processes` defaults to `per_submission = 1`. When present, the value
+must not be 0.
 
 ## threads_per_process
 
@@ -43,11 +44,15 @@ action utilizes per process. When omitted, **row** does not make any specific re
 for threads from the scheduler. Most schedulers default to 1 thread per process in this
 case.
 
+When present, the value must not be 0.
+
 ## gpus_per_process
 
 `action.resources.gpus_per_process`: **integer** - The number of GPUs your action
 utilizes per process. When omitted, **row** does not make any specific request for GPUs
 from the scheduler. Most schedulers default to 0 GPUs per process in this case.
+
+When present, the value must not be 0.
 
 ## walltime
 

--- a/doc/src/workflow/action/resources.md
+++ b/doc/src/workflow/action/resources.md
@@ -34,25 +34,20 @@ to perform computations. Use `per_directory` when your action parallelizes over 
 directories and therefore requires `processes.per_directory * num_directories` total
 processes.
 
-When omitted, `processes` defaults to `per_submission = 1`. When present, the value
-must not be 0.
+When omitted, `processes` defaults to `per_submission = 1`.
 
 ## threads_per_process
 
-`action.resources.threads_per_process`: **integer** - The number of CPU threads your
-action utilizes per process. When omitted, **row** does not make any specific request
-for threads from the scheduler. Most schedulers default to 1 thread per process in this
-case.
-
-When present, the value must not be 0.
+`action.resources.threads_per_process`: **positive integer** - The number of CPU threads
+your action utilizes per process. When omitted, **row** does not make any specific
+request for threads from the scheduler. Most schedulers default to 1 thread per process
+in this case.
 
 ## gpus_per_process
 
-`action.resources.gpus_per_process`: **integer** - The number of GPUs your action
-utilizes per process. When omitted, **row** does not make any specific request for GPUs
-from the scheduler. Most schedulers default to 0 GPUs per process in this case.
-
-When present, the value must not be 0.
+`action.resources.gpus_per_process`: **positive integer** - The number of GPUs your
+action utilizes per process. When omitted, **row** does not make any specific request
+for GPUs from the scheduler. Most schedulers default to 0 GPUs per process in this case.
 
 ## walltime
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,9 +101,6 @@ pub enum Error {
     #[error("Previous action '{0}' not found in action '{1}'.")]
     PreviousActionNotFound(String, String),
 
-    #[error("Define 'processes' or 'processes_per_directory', not both in action '{0}'.")]
-    DuplicateProcesses(String),
-
     #[error("Use '{{directory}}' or '{{directories}}', not both in the command of action '{0}'.")]
     ActionContainsMultipleTemplates(String),
 
@@ -147,6 +144,17 @@ pub enum Error {
 
     #[error("Unable to parse template '{1}' for action '{0}'.")]
     InvalidTemplate(String, String),
+
+    #[error("Action '{0}' must request more than 0 processes or omit `resources.processes`.")]
+    ZeroProcesses(String),
+
+    #[error(
+        "Action '{0}' must request more than 0 threads or omit `resources.threads_per_process`."
+    )]
+    ZeroThreads(String),
+
+    #[error("Action '{0}' must request more than 0 GPUs or omit `resources.gpus_per_process`.")]
+    ZeroGpus(String),
 
     // submission errors
     #[error("Error encountered while executing action '{0}': {1}.")]

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -630,6 +630,24 @@ impl Workflow {
                     warn!("The JSON pointer '{pointer}' does not appear valid. Did you mean '/{pointer}'?");
                 }
             }
+
+            // Users must request more than 0 resources, or omit the relevant key to request none.
+            if matches!(action.resources.processes, Some(Processes::PerDirectory(0)))
+                || matches!(
+                    action.resources.processes,
+                    Some(Processes::PerSubmission(0))
+                )
+            {
+                return Err(Error::ZeroProcesses(action.name().into()));
+            }
+
+            if action.resources.threads_per_process == Some(0) {
+                return Err(Error::ZeroThreads(action.name().into()));
+            }
+
+            if action.resources.gpus_per_process == Some(0) {
+                return Err(Error::ZeroGpus(action.name().into()));
+            }
         }
 
         for action in &self.action {
@@ -1184,6 +1202,102 @@ processes.per_directory = 2
         assert!(
             err.contains("wanted exactly 1 element"),
             "Expected 'wanted exactly 1 element', got {err:?}"
+        );
+    }
+
+    #[test]
+    #[parallel]
+    fn zero_processes_submission() {
+        let temp = TempDir::new().unwrap();
+        let workflow = r#"
+[[action]]
+name = "b"
+command = "c"
+[action.resources]
+processes.per_submission = 0
+"#;
+        let result = Workflow::open_str(temp.path(), workflow);
+        assert!(
+            matches!(result, Err(Error::ZeroProcesses(..))),
+            "Expected zero processes error, but got {result:?}"
+        );
+
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("must request more than 0 processes"),
+            "Expected 'must request more than 0 processes', got {err:?}"
+        );
+    }
+
+    #[test]
+    #[parallel]
+    fn zero_processes_directory() {
+        let temp = TempDir::new().unwrap();
+        let workflow = r#"
+[[action]]
+name = "b"
+command = "c"
+[action.resources]
+processes.per_directory = 0
+"#;
+        let result = Workflow::open_str(temp.path(), workflow);
+        assert!(
+            matches!(result, Err(Error::ZeroProcesses(..))),
+            "Expected zero processes error, but got {result:?}"
+        );
+
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("must request more than 0 processes"),
+            "Expected 'must request more than 0 processes', got {err:?}"
+        );
+    }
+
+    #[test]
+    #[parallel]
+    fn zero_threads() {
+        let temp = TempDir::new().unwrap();
+        let workflow = r#"
+[[action]]
+name = "b"
+command = "c"
+[action.resources]
+threads_per_process = 0
+"#;
+        let result = Workflow::open_str(temp.path(), workflow);
+        assert!(
+            matches!(result, Err(Error::ZeroThreads(..))),
+            "Expected zero threads error, but got {result:?}"
+        );
+
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("must request more than 0 threads"),
+            "Expected 'must request more than 0 threads', got {err:?}"
+        );
+    }
+
+    #[test]
+    #[parallel]
+    fn zero_gpus() {
+        let temp = TempDir::new().unwrap();
+        let workflow = r#"
+[[action]]
+name = "b"
+command = "c"
+[action.resources]
+gpus_per_process = 0
+"#;
+        let result = Workflow::open_str(temp.path(), workflow);
+        assert!(
+            matches!(result, Err(Error::ZeroGpus(..))),
+            "Expected zero GPUs error, but got {result:?}"
+        );
+
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("must request more than 0 GPUs"),
+            "Expected 'must request more than 0 GPUs', got {err:?}"
         );
     }
 


### PR DESCRIPTION
## Description

<!-- Describe your changes. -->
Ensure that users request more than 0 resources.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Row passes values that the user provides directly through to the scheduler. For example, when a user requests `gpus_per_processes = 0`, row will dutifully place `#SBATCH --gpus-per-task=0` in the submission script. At the same time, row interprets `gpus_per_process => Some(_)` as a request for GPUs.

This change validates that the user workflow must request at least 1 process, GPU, and/or thread. It informs the user to omit the request to request no resources.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #86

## How has this been tested?

<!--- Please describe how you tested your changes. -->
Unit tests verify all new errors.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/row/blob/trunk/doc/src/developers/contributing.md).
- [x] I agree with the terms of the [**Row Contributor Agreement**](https://github.com/glotzerlab/row/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/src/contributors.md`) in the pull request source branch.
- [x] I have added a change log entry to `doc/src/release-notes.md`.
