### PR TITLE
Add a doc example for combining `action.group.include` statements

### DIFF
--- a/doc/src/workflow/action/group.md
+++ b/doc/src/workflow/action/group.md
@@ -57,6 +57,15 @@ Compare by array:
 condition = ["/array", "==", [1, "string", 14.0]
 ```
 
+Add additional tables, combining conditions with a logical or:
+```toml
+[[action.group.include]]
+all = [["/value", ">", 0.2], ["/value", "<", 0.9]]
+
+[[action.group.include]]
+condition = ["/value", "==", 0.05]
+```
+
 > Note: **Row** compares arrays *lexicographically*.
 
 <div class="warning">


### PR DESCRIPTION
## Description

Combining multiple conditions is useful in many instances, for example selecting multiple single state points within a workspace:

```toml
[[action.group.include]]
condition = ["/value", "==", 0.0]

[[action.group.include]]
all = [
    ["/other_value", "==", 1.0],
    ["/value", ">", 0.0]
]
```

## Motivation and context

The `toml` array of tables concept was foreign to me, so I couldn't determine how to combine multiple conditions with a logical or. This doc snippet provides an example of how this can be achieved.

## How has this been tested?

Validated that there is a change in number of matched statepoints when combining multiple all, multiple condition, and mixed all/condition statements.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/row/blob/trunk/doc/src/developers/contributing.md).
- [x] I agree with the terms of the [**Row Contributor Agreement**](https://github.com/glotzerlab/row/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/src/contributors.md`) in the pull request source branch.
- [ ] I have added a change log entry to `doc/src/release-notes.md`.
