### PR TITLE
Add `memory_per_cpu_mb` and `memory_per_gpu_mb` to `action.resources`.

### DIFF
--- a/doc/src/clusters/cluster.md
+++ b/doc/src/clusters/cluster.md
@@ -96,11 +96,11 @@ if total_cpus % warn_cpus_not_multiple_of != 0:
 This is a nonblocking variant of `require_cpus_multiple_of` that allows for submission
 of jobs that underutilize resources.
 
-### memory_per_cpu
+### memory_per_cpu_mb
 
-`cluster.partition.memory_per_cpu`: **string** - CPU Jobs submitted to this partition
+`cluster.partition.memory_per_cpu`: **integer** - CPU Jobs submitted to this partition
 will pass this option to the scheduler. For example SLURM schedulers will set
-`--mem-per-cpu=<memory_per_cpu>`.
+`--mem-per-cpu=<memory_per_cpu_mb>M`.
 
 ### cpus_per_node
 
@@ -153,11 +153,11 @@ if total_gpus % warn_gpus_not_multiple_of != 0:
 This is a nonblocking variant of `require_gpus_multiple_of` that allows for submission
 of jobs that underutilize resources.
 
-### memory_per_gpu
+### memory_per_gpu_mb
 
-`cluster.partition.memory_per_gpu`: **string** - GPU Jobs submitted to this partition
+`cluster.partition.memory_per_gpu_mb`: **integer** - GPU Jobs submitted to this partition
 will pass this option to the scheduler. For example SLURM schedulers will set
-`--mem-per-gpu=<memory_per_gpu>`.
+`--mem-per-gpu=<memory_per_gpu_mb>M`.
 
 ### gpus_per_node
 

--- a/doc/src/release-notes.md
+++ b/doc/src/release-notes.md
@@ -38,6 +38,10 @@ extra charges on your HPC resources.
 * Memory requests in `clusters.toml` must now be set in MB. The `memory_per_*`
   keys are renamed to `memory_per_*_mb`.
 
+*Fixed:*
+
+* Submit MPI jobs on Great Lakes without error.
+
 ## 0.4.0 (2024-12-06)
 
 *Highlights:*

--- a/doc/src/release-notes.md
+++ b/doc/src/release-notes.md
@@ -4,11 +4,27 @@
 
 *Highlights:*
 
-**Row** 0.5 improves the user interface and updates the code to meet modern
-Rust standards.
+In **Row** 0.5, the subcommands `show directories`, `show jobs`, and `show status` now
+report `No matches.` when there are no results to show.
 
-The subcommands `show directories`, `show jobs`, and `show status` now report
-`No matches.` when there are no results to show.
+Users can also request an amount of memory specific to an action:
+
+```toml
+[action.resources]
+memory_per_cpu_mb = 1024
+```
+
+**Row** normally sets the memory request automatically to the maximum allowed on the
+partition, so most users should omit the new action-specific memory request keys.
+When set, the given value will be passed to the SLURM option `--mem-per-cpu` or
+`--mem-per-gpu` if the partition has no memory request set or the action's value is
+smaller than the partition's. **Row** returns an error when the user requests more
+memory than the partition has available to prevent unexpected additional costs.
+
+*Added:*
+
+* Actions can request the following new resources: `memory_per_cpu_mb` or
+  `memory_per_gpu_mb`.
 
 *Changed:*
 
@@ -16,6 +32,8 @@ The subcommands `show directories`, `show jobs`, and `show status` now report
 * Build executables on Ubuntu 22.04.
 * Report an error when the workflow requests 0 processes, GPUs, or threads.
 * Require Rust 1.85 or newer to build.
+* Memory requests in `clusters.toml` must now be set in MB. The `memory_per_*`
+  keys are renamed to `memory_per_*_mb`.
 
 ## 0.4.0 (2024-12-06)
 

--- a/doc/src/release-notes.md
+++ b/doc/src/release-notes.md
@@ -5,21 +5,24 @@
 *Highlights:*
 
 In **Row** 0.5, the subcommands `show directories`, `show jobs`, and `show status` now
-report `No matches.` when there are no results to show.
+report `No matches` when there are no results to show.
 
-Users can also request an amount of memory specific to an action:
+Users can also request an amount of memory specific to an action with
+`memory_per_cpu_mb` or `memory_per_gpu_mb`. For example:
 
 ```toml
 [action.resources]
 memory_per_cpu_mb = 1024
 ```
 
-**Row** normally sets the memory request automatically to the maximum allowed on the
-partition, so most users should omit the new action-specific memory request keys.
 When set, the given value will be passed to the SLURM option `--mem-per-cpu` or
 `--mem-per-gpu` if the partition has no memory request set or the action's value is
 smaller than the partition's. **Row** returns an error when the user requests more
 memory than the partition has available to prevent unexpected additional costs.
+
+> Note: Most users should omit the memory request. When omitted **row** will
+automatically select the maximum amount of memory possible without incurring
+extra charges on your HPC resources.
 
 *Added:*
 

--- a/doc/src/workflow/action/resources.md
+++ b/doc/src/workflow/action/resources.md
@@ -76,7 +76,7 @@ When omitted, `walltime` defaults to `per_directory = 01:00:00`.
 ## memory_per_cpu_mb
 
 `action.resources.memory_per_cpu_mb`: **integer** - The number of megabytes of memory to
-request per CPU (thread). `memory_per_cpu_mb is used when `gpus_per_process` is unset.
+request per CPU (thread). `memory_per_cpu_mb` is used when `gpus_per_process` is unset.
 
 > Note: Most users should omit `memory_per_cpu_mb`. When omitted **row** will
 automatically select the maximum amount of memory possible without incurring

--- a/doc/src/workflow/action/resources.md
+++ b/doc/src/workflow/action/resources.md
@@ -72,3 +72,17 @@ independent of the submission group size. Use `per_directory` when your action l
 over the directories and therefore the walltime scales with the number of directories.
 
 When omitted, `walltime` defaults to `per_directory = 01:00:00`.
+
+## memory_per_cpu_mb
+
+`action.resources.memory_per_cpu_mb`: **integer** - The number of megabytes of memory to
+request per CPU (thread). `memory_per_cpu_mb is used when `gpus_per_process` is unset.
+
+> Note: Most users should omit `memory_per_cpu_mb`. When omitted **row** will
+automatically select the maximum amount of memory possible without incurring
+extra charges on your HPC resources.
+
+## memory_per_gpu_mb
+
+Similar to `memory_per_cpu_mb`, but for GPUs. `memory_per_gpu_mb` is used when
+`gpus_per_process` is set.

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -236,7 +236,6 @@ fn greatlakes() -> Cluster {
             Partition {
                 name: "standard".into(),
                 maximum_gpus_per_job: Some(0),
-                cpus_per_node: Some(36),
                 memory_per_cpu_mb: Some(5 * 1024),
                 ..Partition::default()
             },
@@ -278,7 +277,6 @@ fn greatlakes() -> Cluster {
             Partition {
                 name: "standard-oc".into(),
                 maximum_gpus_per_job: Some(0),
-                cpus_per_node: Some(36),
                 memory_per_cpu_mb: Some(5 * 1024),
                 prevent_auto_select: true,
                 ..Partition::default()
@@ -286,7 +284,6 @@ fn greatlakes() -> Cluster {
             Partition {
                 name: "debug".into(),
                 maximum_gpus_per_job: Some(0),
-                cpus_per_node: Some(36),
                 memory_per_cpu_mb: Some(5 * 1024),
                 prevent_auto_select: true,
                 ..Partition::default()

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -99,6 +99,7 @@ fn anvil() -> Cluster {
                 name: "shared".into(),
                 maximum_cpus_per_job: Some(127),
                 maximum_gpus_per_job: Some(0),
+                memory_per_cpu_mb: Some(1800),
                 ..Partition::default()
             },
             Partition {
@@ -125,6 +126,7 @@ fn anvil() -> Cluster {
                 name: "highmem".into(),
                 maximum_gpus_per_job: Some(0),
                 prevent_auto_select: true,
+                memory_per_cpu_mb: Some(7900),
                 ..Partition::default()
             },
             Partition {

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -157,14 +157,14 @@ fn delta() -> Cluster {
                 name: "cpu".into(),
                 maximum_gpus_per_job: Some(0),
                 cpus_per_node: Some(128),
-                memory_per_cpu: Some("1970M".into()),
+                memory_per_cpu_mb: Some(1_970),
                 account_suffix: Some("-cpu".into()),
                 ..Partition::default()
             },
             Partition {
                 name: "gpuA100x4".into(),
                 minimum_gpus_per_job: Some(1),
-                memory_per_gpu: Some("62200M".into()),
+                memory_per_gpu_mb: Some(62_200),
                 gpus_per_node: Some(4),
                 account_suffix: Some("-gpu".into()),
                 ..Partition::default()
@@ -173,7 +173,7 @@ fn delta() -> Cluster {
             Partition {
                 name: "gpuA100x8".into(),
                 minimum_gpus_per_job: Some(1),
-                memory_per_gpu: Some("256000M".into()),
+                memory_per_gpu_mb: Some(256_000),
                 gpus_per_node: Some(8),
                 account_suffix: Some("-gpu".into()),
                 prevent_auto_select: true,
@@ -182,7 +182,7 @@ fn delta() -> Cluster {
             Partition {
                 name: "gpuA40x4".into(),
                 minimum_gpus_per_job: Some(1),
-                memory_per_gpu: Some("62200M".into()),
+                memory_per_gpu_mb: Some(62_200),
                 gpus_per_node: Some(4),
                 account_suffix: Some("-gpu".into()),
                 prevent_auto_select: true,
@@ -191,7 +191,7 @@ fn delta() -> Cluster {
             Partition {
                 name: "gpuMI100x8".into(),
                 minimum_gpus_per_job: Some(1),
-                memory_per_gpu: Some("256000M".into()),
+                memory_per_gpu_mb: Some(256_000),
                 gpus_per_node: Some(8),
                 account_suffix: Some("-gpu".into()),
                 prevent_auto_select: true,
@@ -235,20 +235,20 @@ fn greatlakes() -> Cluster {
                 name: "standard".into(),
                 maximum_gpus_per_job: Some(0),
                 cpus_per_node: Some(36),
-                memory_per_cpu: Some("5G".into()),
+                memory_per_cpu_mb: Some(5 * 1024),
                 ..Partition::default()
             },
             Partition {
                 name: "gpu_mig40,gpu".into(),
                 minimum_gpus_per_job: Some(1),
                 maximum_gpus_per_job: Some(1),
-                memory_per_gpu: Some("60G".into()),
+                memory_per_gpu_mb: Some(60 * 1024),
                 ..Partition::default()
             },
             Partition {
                 name: "gpu".into(),
                 minimum_gpus_per_job: Some(1),
-                memory_per_gpu: Some("60G".into()),
+                memory_per_gpu_mb: Some(60 * 1024),
                 // cannot set gpus_per_node, the partition is heterogeneous
                 ..Partition::default()
             },
@@ -256,14 +256,14 @@ fn greatlakes() -> Cluster {
             Partition {
                 name: "gpu_mig40".into(),
                 minimum_gpus_per_job: Some(1),
-                memory_per_gpu: Some("125G".into()),
+                memory_per_gpu_mb: Some(125 * 1024),
                 prevent_auto_select: true,
                 ..Partition::default()
             },
             Partition {
                 name: "spgpu".into(),
                 minimum_gpus_per_job: Some(1),
-                memory_per_gpu: Some("47000M".into()),
+                memory_per_gpu_mb: Some(47_000),
                 prevent_auto_select: true,
                 ..Partition::default()
             },
@@ -277,7 +277,7 @@ fn greatlakes() -> Cluster {
                 name: "standard-oc".into(),
                 maximum_gpus_per_job: Some(0),
                 cpus_per_node: Some(36),
-                memory_per_cpu: Some("5G".into()),
+                memory_per_cpu_mb: Some(5 * 1024),
                 prevent_auto_select: true,
                 ..Partition::default()
             },
@@ -285,7 +285,7 @@ fn greatlakes() -> Cluster {
                 name: "debug".into(),
                 maximum_gpus_per_job: Some(0),
                 cpus_per_node: Some(36),
-                memory_per_cpu: Some("5G".into()),
+                memory_per_cpu_mb: Some(5 * 1024),
                 prevent_auto_select: true,
                 ..Partition::default()
             },

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -86,7 +86,7 @@ pub struct Partition {
     pub warn_cpus_not_multiple_of: Option<usize>,
 
     /// Memory per CPU.
-    pub memory_per_cpu: Option<String>,
+    pub memory_per_cpu_mb: Option<usize>,
 
     /// CPUs per node.
     pub cpus_per_node: Option<usize>,
@@ -104,7 +104,7 @@ pub struct Partition {
     pub warn_gpus_not_multiple_of: Option<usize>,
 
     /// Memory per GPU.
-    pub memory_per_gpu: Option<String>,
+    pub memory_per_gpu_mb: Option<usize>,
 
     /// GPUs per node.
     pub gpus_per_node: Option<usize>,
@@ -358,13 +358,13 @@ impl Default for Partition {
         Partition {
             name: "partition".into(),
             maximum_cpus_per_job: None,
-            memory_per_cpu: None,
+            memory_per_cpu_mb: None,
             cpus_per_node: None,
             require_cpus_multiple_of: None,
             warn_cpus_not_multiple_of: None,
             minimum_gpus_per_job: None,
             maximum_gpus_per_job: None,
-            memory_per_gpu: None,
+            memory_per_gpu_mb: None,
             gpus_per_node: None,
             require_gpus_multiple_of: None,
             warn_gpus_not_multiple_of: None,
@@ -771,12 +771,12 @@ name = "d"
 maximum_cpus_per_job = 2
 require_cpus_multiple_of = 4
 warn_cpus_not_multiple_of = 4
-memory_per_cpu = "e"
+memory_per_cpu_mb = 50
 minimum_gpus_per_job = 8
 maximum_gpus_per_job = 16
 require_gpus_multiple_of = 32
 warn_gpus_not_multiple_of = 32
-memory_per_gpu = "f"
+memory_per_gpu_mb = 100
 cpus_per_node = 10
 gpus_per_node = 11
 account_suffix = "-gpu"
@@ -803,12 +803,12 @@ account_suffix = "-gpu"
                 maximum_cpus_per_job: Some(2),
                 require_cpus_multiple_of: Some(4),
                 warn_cpus_not_multiple_of: Some(4),
-                memory_per_cpu: Some("e".into()),
+                memory_per_cpu_mb: Some(50),
                 minimum_gpus_per_job: Some(8),
                 maximum_gpus_per_job: Some(16),
                 require_gpus_multiple_of: Some(32),
                 warn_gpus_not_multiple_of: Some(32),
-                memory_per_gpu: Some("f".into()),
+                memory_per_gpu_mb: Some(100),
                 prevent_auto_select: false,
                 cpus_per_node: Some(10),
                 gpus_per_node: Some(11),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,6 +177,9 @@ pub enum Error {
     )]
     WouldSubmitMultipleTimes(PathBuf, String),
 
+    #[error("Action '{0}' requests too much memory: {1}M.")]
+    TooMuchMemory(String, usize),
+
     // launcher errors
     #[error("Launcher '{0}' does not contain a default configuration")]
     LauncherMissingDefault(String),

--- a/src/scheduler/bash.rs
+++ b/src/scheduler/bash.rs
@@ -469,7 +469,7 @@ mod tests {
             walltime: Some(Walltime::PerSubmission(
                 Duration::new(true, 0, 240, 0).expect("Valid duration."),
             )),
-            .. Resources::default()
+            ..Resources::default()
         };
 
         let action = Action {

--- a/src/scheduler/bash.rs
+++ b/src/scheduler/bash.rs
@@ -469,6 +469,7 @@ mod tests {
             walltime: Some(Walltime::PerSubmission(
                 Duration::new(true, 0, 240, 0).expect("Valid duration."),
             )),
+            .. Resources::default()
         };
 
         let action = Action {

--- a/src/scheduler/slurm.rs
+++ b/src/scheduler/slurm.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of row, released under the BSD 3-Clause License.
 
-use log::{debug, error, trace};
+use log::{debug, error, trace, warn};
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
@@ -102,9 +102,17 @@ impl Scheduler for Slurm {
                 let _ = writeln!(preamble, "#SBATCH --nodes={n_nodes}");
             }
 
-            if let Some(ref mem_per_gpu_mb) = partition.memory_per_gpu_mb {
-                let _ = writeln!(preamble, "#SBATCH --mem-per-gpu={mem_per_gpu_mb}M");
-            }
+            match (action.resources.memory_per_gpu_mb, partition.memory_per_gpu_mb) {
+                (None, Some(mem)) | (Some(mem), None) => {let _ = writeln!(preamble, "#SBATCH --mem-per-gpu={mem}M");},
+                (Some(mem_action), Some(mem_partition)) => { if mem_action < mem_partition {
+                    warn!("Omit `memory_per_gpu_mb` in action '{}' to request more memory at no cost.", action.name());
+                    let _ = writeln!(preamble, "#SBATCH --mem-per-gpu={mem_action}M");
+                    } else {
+                        return Err(Error::TooMuchMemory(action.name().into(), mem_action));
+                        }
+                }
+                (None, None) => {}
+            }               
         } else {
             if let Some(ref cpus_per_node) = partition.cpus_per_node {
                 let n_nodes = action
@@ -114,8 +122,16 @@ impl Scheduler for Slurm {
                 let _ = writeln!(preamble, "#SBATCH --nodes={n_nodes}");
             }
 
-            if let Some(ref mem_per_cpu_mb) = partition.memory_per_cpu_mb {
-                let _ = writeln!(preamble, "#SBATCH --mem-per-cpu={mem_per_cpu_mb}M");
+            match (action.resources.memory_per_cpu_mb, partition.memory_per_cpu_mb) {
+                (None, Some(mem)) | (Some(mem), None) => {let _ = writeln!(preamble, "#SBATCH --mem-per-cpu={mem}M");},
+                (Some(mem_action), Some(mem_partition)) => { if mem_action < mem_partition {
+                    warn!("Omit `memory_per_cpu_mb` in action '{}' to request more memory at no cost.", action.name());
+                    let _ = writeln!(preamble, "#SBATCH --mem-per-cpu={mem_action}M");
+                    } else {
+                        return Err(Error::TooMuchMemory(action.name().into(), mem_action));
+                        }
+                }
+                (None, None) => {}
             }
         }
 
@@ -462,7 +478,7 @@ mod tests {
     #[test]
     #[parallel]
     fn mem_per_cpu() {
-        let (action, directories, _) = setup();
+        let (mut action, directories, _) = setup();
 
         let launchers = launcher::Configuration::built_in();
         let cluster = Cluster {
@@ -484,6 +500,21 @@ mod tests {
         println!("{script}");
 
         assert!(script.contains("#SBATCH --mem-per-cpu=5M"));
+
+        action.resources.memory_per_cpu_mb = Some(2);
+
+        let script = slurm
+            .make_script(&action, &directories, &PathBuf::default(), &HashMap::new())
+            .expect("valid script");
+        println!("{script}");
+
+        assert!(script.contains("#SBATCH --mem-per-cpu=2M"));
+
+        action.resources.memory_per_cpu_mb = Some(10);
+
+        assert!(matches!(slurm
+            .make_script(&action, &directories, &PathBuf::default(), &HashMap::new()),
+            Err(Error::TooMuchMemory(_, _))));
     }
 
     #[test]
@@ -513,6 +544,21 @@ mod tests {
         println!("{script}");
 
         assert!(script.contains("#SBATCH --mem-per-gpu=12M"));
+
+        action.resources.memory_per_gpu_mb = Some(4);
+
+        let script = slurm
+            .make_script(&action, &directories, &PathBuf::default(), &HashMap::new())
+            .expect("valid script");
+        println!("{script}");
+
+        assert!(script.contains("#SBATCH --mem-per-gpu=4M"));
+
+        action.resources.memory_per_gpu_mb = Some(20);
+
+        assert!(matches!(slurm
+            .make_script(&action, &directories, &PathBuf::default(), &HashMap::new()),
+            Err(Error::TooMuchMemory(_, _))));
     }
 
     #[test]

--- a/src/scheduler/slurm.rs
+++ b/src/scheduler/slurm.rs
@@ -31,6 +31,31 @@ impl Slurm {
     pub fn new(cluster: Cluster, launchers: HashMap<String, Launcher>) -> Self {
         Self { cluster, launchers }
     }
+
+    fn write_mem_per(preamble: &mut String, action_mem: Option<usize>, partition_mem: Option<usize>, processor_type: &str, action_name: &str) -> Result<(), Error> {
+
+            match (
+                action_mem,
+                partition_mem,
+            ) {
+                (None, Some(mem)) | (Some(mem), None) => {
+                    let _ = writeln!(preamble, "#SBATCH --mem-per-{processor_type}={mem}M");
+                }
+                (Some(mem_action), Some(mem_partition)) => {
+                    if mem_action < mem_partition {
+                        warn!(
+                            "Omit `memory_per_{processor_type}_mb` in action '{action_name}' to request more memory at no cost."
+                        );
+                        let _ = writeln!(preamble, "#SBATCH --mem-per-{processor_type}={mem_action}M");
+                    } else {
+                        return Err(Error::TooMuchMemory(action_name.into(), mem_action));
+                    }
+                }
+                (None, None) => {}
+            }
+
+    Ok(())
+    }
 }
 
 /** Track the running squeue process
@@ -43,6 +68,7 @@ pub struct ActiveSlurmJobs {
 }
 
 impl Scheduler for Slurm {
+
     fn make_script(
         &self,
         action: &Action,
@@ -102,17 +128,7 @@ impl Scheduler for Slurm {
                 let _ = writeln!(preamble, "#SBATCH --nodes={n_nodes}");
             }
 
-            match (action.resources.memory_per_gpu_mb, partition.memory_per_gpu_mb) {
-                (None, Some(mem)) | (Some(mem), None) => {let _ = writeln!(preamble, "#SBATCH --mem-per-gpu={mem}M");},
-                (Some(mem_action), Some(mem_partition)) => { if mem_action < mem_partition {
-                    warn!("Omit `memory_per_gpu_mb` in action '{}' to request more memory at no cost.", action.name());
-                    let _ = writeln!(preamble, "#SBATCH --mem-per-gpu={mem_action}M");
-                    } else {
-                        return Err(Error::TooMuchMemory(action.name().into(), mem_action));
-                        }
-                }
-                (None, None) => {}
-            }               
+            Slurm::write_mem_per(&mut preamble, action.resources.memory_per_gpu_mb, partition.memory_per_gpu_mb, "gpu", action.name())?;
         } else {
             if let Some(ref cpus_per_node) = partition.cpus_per_node {
                 let n_nodes = action
@@ -122,17 +138,7 @@ impl Scheduler for Slurm {
                 let _ = writeln!(preamble, "#SBATCH --nodes={n_nodes}");
             }
 
-            match (action.resources.memory_per_cpu_mb, partition.memory_per_cpu_mb) {
-                (None, Some(mem)) | (Some(mem), None) => {let _ = writeln!(preamble, "#SBATCH --mem-per-cpu={mem}M");},
-                (Some(mem_action), Some(mem_partition)) => { if mem_action < mem_partition {
-                    warn!("Omit `memory_per_cpu_mb` in action '{}' to request more memory at no cost.", action.name());
-                    let _ = writeln!(preamble, "#SBATCH --mem-per-cpu={mem_action}M");
-                    } else {
-                        return Err(Error::TooMuchMemory(action.name().into(), mem_action));
-                        }
-                }
-                (None, None) => {}
-            }
+            Slurm::write_mem_per(&mut preamble, action.resources.memory_per_cpu_mb, partition.memory_per_cpu_mb, "cpu", action.name())?;
         }
 
         // Slurm doesn't store times in seconds, so round up to the nearest minute.
@@ -512,9 +518,10 @@ mod tests {
 
         action.resources.memory_per_cpu_mb = Some(10);
 
-        assert!(matches!(slurm
-            .make_script(&action, &directories, &PathBuf::default(), &HashMap::new()),
-            Err(Error::TooMuchMemory(_, _))));
+        assert!(matches!(
+            slurm.make_script(&action, &directories, &PathBuf::default(), &HashMap::new()),
+            Err(Error::TooMuchMemory(_, _))
+        ));
     }
 
     #[test]
@@ -556,9 +563,10 @@ mod tests {
 
         action.resources.memory_per_gpu_mb = Some(20);
 
-        assert!(matches!(slurm
-            .make_script(&action, &directories, &PathBuf::default(), &HashMap::new()),
-            Err(Error::TooMuchMemory(_, _))));
+        assert!(matches!(
+            slurm.make_script(&action, &directories, &PathBuf::default(), &HashMap::new()),
+            Err(Error::TooMuchMemory(_, _))
+        ));
     }
 
     #[test]

--- a/src/scheduler/slurm.rs
+++ b/src/scheduler/slurm.rs
@@ -102,8 +102,8 @@ impl Scheduler for Slurm {
                 let _ = writeln!(preamble, "#SBATCH --nodes={n_nodes}");
             }
 
-            if let Some(ref mem_per_gpu) = partition.memory_per_gpu {
-                let _ = writeln!(preamble, "#SBATCH --mem-per-gpu={mem_per_gpu}");
+            if let Some(ref mem_per_gpu_mb) = partition.memory_per_gpu_mb {
+                let _ = writeln!(preamble, "#SBATCH --mem-per-gpu={mem_per_gpu_mb}M");
             }
         } else {
             if let Some(ref cpus_per_node) = partition.cpus_per_node {
@@ -114,8 +114,8 @@ impl Scheduler for Slurm {
                 let _ = writeln!(preamble, "#SBATCH --nodes={n_nodes}");
             }
 
-            if let Some(ref mem_per_cpu) = partition.memory_per_cpu {
-                let _ = writeln!(preamble, "#SBATCH --mem-per-cpu={mem_per_cpu}");
+            if let Some(ref mem_per_cpu_mb) = partition.memory_per_cpu_mb {
+                let _ = writeln!(preamble, "#SBATCH --mem-per-cpu={mem_per_cpu_mb}M");
             }
         }
 
@@ -471,7 +471,7 @@ mod tests {
             scheduler: SchedulerType::Slurm,
             submit_options: Vec::new(),
             partition: vec![Partition {
-                memory_per_cpu: Some("a".into()),
+                memory_per_cpu_mb: Some(5),
                 ..Partition::default()
             }],
         };
@@ -483,7 +483,7 @@ mod tests {
             .expect("valid script");
         println!("{script}");
 
-        assert!(script.contains("#SBATCH --mem-per-cpu=a"));
+        assert!(script.contains("#SBATCH --mem-per-cpu=5M"));
     }
 
     #[test]
@@ -498,7 +498,7 @@ mod tests {
             scheduler: SchedulerType::Slurm,
             submit_options: Vec::new(),
             partition: vec![Partition {
-                memory_per_gpu: Some("b".into()),
+                memory_per_gpu_mb: Some(12),
                 ..Partition::default()
             }],
         };
@@ -512,7 +512,7 @@ mod tests {
             .expect("valid script");
         println!("{script}");
 
-        assert!(script.contains("#SBATCH --mem-per-gpu=b"));
+        assert!(script.contains("#SBATCH --mem-per-gpu=12M"));
     }
 
     #[test]

--- a/src/scheduler/slurm.rs
+++ b/src/scheduler/slurm.rs
@@ -32,29 +32,31 @@ impl Slurm {
         Self { cluster, launchers }
     }
 
-    fn write_mem_per(preamble: &mut String, action_mem: Option<usize>, partition_mem: Option<usize>, processor_type: &str, action_name: &str) -> Result<(), Error> {
-
-            match (
-                action_mem,
-                partition_mem,
-            ) {
-                (None, Some(mem)) | (Some(mem), None) => {
-                    let _ = writeln!(preamble, "#SBATCH --mem-per-{processor_type}={mem}M");
-                }
-                (Some(mem_action), Some(mem_partition)) => {
-                    if mem_action < mem_partition {
-                        warn!(
-                            "Omit `memory_per_{processor_type}_mb` in action '{action_name}' to request more memory at no cost."
-                        );
-                        let _ = writeln!(preamble, "#SBATCH --mem-per-{processor_type}={mem_action}M");
-                    } else {
-                        return Err(Error::TooMuchMemory(action_name.into(), mem_action));
-                    }
-                }
-                (None, None) => {}
+    fn write_mem_per(
+        preamble: &mut String,
+        action_mem: Option<usize>,
+        partition_mem: Option<usize>,
+        processor_type: &str,
+        action_name: &str,
+    ) -> Result<(), Error> {
+        match (action_mem, partition_mem) {
+            (None, Some(mem)) | (Some(mem), None) => {
+                let _ = writeln!(preamble, "#SBATCH --mem-per-{processor_type}={mem}M");
             }
+            (Some(mem_action), Some(mem_partition)) => {
+                if mem_action < mem_partition {
+                    warn!(
+                        "Omit `memory_per_{processor_type}_mb` in action '{action_name}' to request more memory at no cost."
+                    );
+                    let _ = writeln!(preamble, "#SBATCH --mem-per-{processor_type}={mem_action}M");
+                } else {
+                    return Err(Error::TooMuchMemory(action_name.into(), mem_action));
+                }
+            }
+            (None, None) => {}
+        }
 
-    Ok(())
+        Ok(())
     }
 }
 
@@ -68,7 +70,6 @@ pub struct ActiveSlurmJobs {
 }
 
 impl Scheduler for Slurm {
-
     fn make_script(
         &self,
         action: &Action,
@@ -128,7 +129,13 @@ impl Scheduler for Slurm {
                 let _ = writeln!(preamble, "#SBATCH --nodes={n_nodes}");
             }
 
-            Slurm::write_mem_per(&mut preamble, action.resources.memory_per_gpu_mb, partition.memory_per_gpu_mb, "gpu", action.name())?;
+            Slurm::write_mem_per(
+                &mut preamble,
+                action.resources.memory_per_gpu_mb,
+                partition.memory_per_gpu_mb,
+                "gpu",
+                action.name(),
+            )?;
         } else {
             if let Some(ref cpus_per_node) = partition.cpus_per_node {
                 let n_nodes = action
@@ -138,7 +145,13 @@ impl Scheduler for Slurm {
                 let _ = writeln!(preamble, "#SBATCH --nodes={n_nodes}");
             }
 
-            Slurm::write_mem_per(&mut preamble, action.resources.memory_per_cpu_mb, partition.memory_per_cpu_mb, "cpu", action.name())?;
+            Slurm::write_mem_per(
+                &mut preamble,
+                action.resources.memory_per_cpu_mb,
+                partition.memory_per_cpu_mb,
+                "cpu",
+                action.name(),
+            )?;
         }
 
         // Slurm doesn't store times in seconds, so round up to the nearest minute.

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -402,10 +402,12 @@ impl Resources {
             self.walltime.clone_from(&template.walltime);
         }
         if self.memory_per_cpu_mb.is_none() {
-            self.memory_per_cpu_mb.clone_from(&template.memory_per_cpu_mb);
+            self.memory_per_cpu_mb
+                .clone_from(&template.memory_per_cpu_mb);
         }
         if self.memory_per_gpu_mb.is_none() {
-            self.memory_per_gpu_mb.clone_from(&template.memory_per_gpu_mb);
+            self.memory_per_gpu_mb
+                .clone_from(&template.memory_per_gpu_mb);
         }
     }
 

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -162,6 +162,12 @@ pub struct Resources {
 
     // Walltime.
     pub walltime: Option<Walltime>,
+
+    // Memory per CPU (in MB).
+    pub memory_per_cpu_mb: Option<usize>,
+
+    // Memory per GPU (in MB).
+    pub memory_per_gpu_mb: Option<usize>,
 }
 
 /// Comparison operations
@@ -394,6 +400,12 @@ impl Resources {
         }
         if self.walltime.is_none() {
             self.walltime.clone_from(&template.walltime);
+        }
+        if self.memory_per_cpu_mb.is_none() {
+            self.memory_per_cpu_mb.clone_from(&template.memory_per_cpu_mb);
+        }
+        if self.memory_per_gpu_mb.is_none() {
+            self.memory_per_gpu_mb.clone_from(&template.memory_per_gpu_mb);
         }
     }
 
@@ -900,6 +912,8 @@ command = "c"
         assert_eq!(action.resources.threads_per_process, None);
         assert_eq!(action.resources.gpus_per_process, None);
         assert_eq!(action.resources.walltime, None,);
+        assert_eq!(action.resources.memory_per_cpu_mb, None,);
+        assert_eq!(action.resources.memory_per_gpu_mb, None,);
         assert_eq!(
             action.resources.walltime(),
             Walltime::PerDirectory(Duration::new(true, 0, 3600, 0).unwrap())
@@ -1145,6 +1159,8 @@ processes.per_submission = 12
 threads_per_process = 8
 gpus_per_process = 1
 walltime.per_submission = "4d, 05:32:11"
+memory_per_cpu_mb = 18
+memory_per_gpu_mb = 26
 "#;
 
         let workflow = Workflow::open_str(temp.path(), workflow).unwrap();
@@ -1162,6 +1178,8 @@ walltime.per_submission = "4d, 05:32:11"
                     .expect("this should be a valid Duration"),
             )
         );
+        assert_eq!(action.resources.memory_per_cpu_mb, Some(18));
+        assert_eq!(action.resources.memory_per_gpu_mb, Some(26));
     }
 
     #[test]
@@ -1665,6 +1683,8 @@ processes.per_directory = 2
 threads_per_process = 3
 gpus_per_process = 4
 walltime.per_submission = "00:00:01"
+memory_per_cpu_mb = 34
+memory_per_gpu_mb = 87
 
 # submit_options is tested above
 
@@ -1700,6 +1720,8 @@ name = "d"
             action.resources.walltime(),
             Walltime::PerSubmission(Duration::new(true, 0, 1, 0).unwrap())
         );
+        assert_eq!(action.resources.memory_per_cpu_mb, Some(34));
+        assert_eq!(action.resources.memory_per_gpu_mb, Some(87));
         assert!(action.submit_options.is_empty());
         assert_eq!(
             action.group.include(),
@@ -1733,6 +1755,8 @@ processes.per_directory = 2
 threads_per_process = 3
 gpus_per_process = 4
 walltime.per_submission = "00:00:01"
+memory_per_cpu_mb = 34
+memory_per_gpu_mb = 87
 
 # submit_options is tested above
 
@@ -1757,6 +1781,8 @@ processes.per_directory = 4
 threads_per_process = 6
 gpus_per_process = 8
 walltime.per_submission = "00:00:02"
+memory_per_cpu_mb = 89
+memory_per_gpu_mb = 22
 
 # submit_options is tested above
 
@@ -1790,6 +1816,8 @@ name = "dd"
             action.resources.walltime(),
             Walltime::PerSubmission(Duration::new(true, 0, 2, 0).unwrap())
         );
+        assert_eq!(action.resources.memory_per_cpu_mb, Some(89));
+        assert_eq!(action.resources.memory_per_gpu_mb, Some(22));
         assert!(action.submit_options.is_empty());
         assert_eq!(
             action.group.include(),
@@ -1824,6 +1852,8 @@ processes.per_directory = 2
 threads_per_process = 3
 gpus_per_process = 4
 walltime.per_submission = "00:00:01"
+memory_per_cpu_mb = 34
+memory_per_gpu_mb = 87
 
 # submit_options is tested above
 
@@ -1861,6 +1891,8 @@ command = "e"
             action.resources.walltime(),
             Walltime::PerSubmission(Duration::new(true, 0, 1, 0).unwrap())
         );
+        assert_eq!(action.resources.memory_per_cpu_mb, Some(34));
+        assert_eq!(action.resources.memory_per_gpu_mb, Some(87));
         assert!(action.submit_options.is_empty());
         assert_eq!(
             action.group.include(),
@@ -1895,6 +1927,8 @@ processes.per_directory = 2
 threads_per_process = 3
 gpus_per_process = 4
 walltime.per_submission = "00:00:01"
+memory_per_cpu_mb = 34
+memory_per_gpu_mb = 87
 
 # submit_options is tested above
 
@@ -1921,6 +1955,8 @@ processes.per_directory = 4
 threads_per_process = 6
 gpus_per_process = 8
 walltime.per_submission = "00:00:02"
+memory_per_cpu_mb = 16
+memory_per_gpu_mb = 12
 
 # submit_options is tested above
 
@@ -1959,6 +1995,8 @@ command = "e"
             action.resources.walltime(),
             Walltime::PerSubmission(Duration::new(true, 0, 2, 0).unwrap())
         );
+        assert_eq!(action.resources.memory_per_cpu_mb, Some(16));
+        assert_eq!(action.resources.memory_per_gpu_mb, Some(12));
         assert!(action.submit_options.is_empty());
         assert_eq!(
             action.group.include(),
@@ -2155,6 +2193,7 @@ resources.processes.per_directory = 8
             )),
             threads_per_process: Some(4),
             gpus_per_process: Some(2),
+            ..Resources::default()
         };
 
         assert_eq!(r.cost(1), ResourceCost::with_values(0.0, 20.0));


### PR DESCRIPTION
## Description

<!-- Describe your changes. -->
Allow users to request memory (in MB) specific to each action. Such a request is redundant when the partition configuration already includes it. **Row** warns the user when they request less than they could and errors when they request more. On partitions with no explicit memory request, the action-specific request will be passed through.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Some clusters allow users to request any amount of memory, therefore a single default value is not appropriate.

Resolves #84.

## How has this been tested?

<!--- Please describe how you tested your changes. -->
- [x] New unit tests pass.
- [x] Validate Anvil
- [x] Validate Great Lakes
- [x] Validate Delta
- [x] Checked the HTML doc formatting.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/row/blob/trunk/doc/src/developers/contributing.md).
- [x] I agree with the terms of the [**Row Contributor Agreement**](https://github.com/glotzerlab/row/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/src/contributors.md`) in the pull request source branch.
- [x] I have added a change log entry to `doc/src/release-notes.md`.
