### PR TITLE
Add output path

### DIFF
--- a/doc/src/contributors.md
+++ b/doc/src/contributors.md
@@ -8,3 +8,4 @@ The following people have contributed to the development of **row**:
 * Kate Jensen, University of Michigan
 * Tim Moore, University of Michigan
 * Corwin Kerr, University of Michigan
+* Trevor Teague, University of Michigan

--- a/doc/src/release-notes.md
+++ b/doc/src/release-notes.md
@@ -1,4 +1,10 @@
 # Release notes
+## 0.5.1 (2025-04-28)
+*Added:*
+
+* Users may now specify the desired name and directory for output files generated
+  by the scheduler by specifying `output_file_path` and `output_file_name` as submission
+  options.
 
 ## 0.5.0 (2025-04-21)
 

--- a/doc/src/release-notes.md
+++ b/doc/src/release-notes.md
@@ -1,5 +1,6 @@
 # Release notes
-## 0.5.1 (2025-04-28)
+
+## 0.6.0 (not yet released)
 *Added:*
 
 * Users may now specify the desired name and directory for output files generated

--- a/doc/src/workflow/action/submit-options.md
+++ b/doc/src/workflow/action/submit-options.md
@@ -59,16 +59,16 @@ will automatically determine the correct partition based on the configuration in
 
 
 ## `<name>.output_file_path`
-`action.submit_options.<name>.output_file_path`: **string** - Set the directory 
+`action.submit_options.<name>.output_file_path`: **string** - Set the directory
 in which to place the output file when submitting jobs to the queue on cluster `<name>`.
-When omitted, the file will be placed in the scheduler's default location (usually the 
+When omitted, the file will be placed in the scheduler's default location (usually the
 location the action is run from).
 
 ## `<name>.output_file_name`
 `action.submit_options.<name>.output_file_name`: **string** - Set the name of the output
-file created when submitting jobs to the queue on cluster `<name>`. The name of the 
-action can be included in the file name by including '{action_name}' within the 
-specified string. Additionally, information about the job known to slurm can be 
-included using certain replacement symbols (c.f. the symbols documented in the 
+file created when submitting jobs to the queue on cluster `<name>`. The name of the
+action can be included in the file name by including '{action_name}' within the
+specified string. Additionally, information about the job known to slurm can be
+included using certain replacement symbols (c.f. the symbols documented in the
 [slurm documentation](https://slurm.schedmd.com/sbatch.html#SECTION_FILENAME-PATTERN)).
 When omitted, the file is set to a default value of '{action_name}-%j.out'.

--- a/doc/src/workflow/action/submit-options.md
+++ b/doc/src/workflow/action/submit-options.md
@@ -18,6 +18,8 @@ partition = "shared"
 [action.submit_options.cluster2]
 account = "other_account"
 setup = "module load openmpi"
+output_file_path = "path/to/directory"
+output_file_name = "{action_name}-%j.out"
 ```
 
 > Note: You may omit `[submit_options]` entirely.
@@ -54,3 +56,15 @@ will automatically determine the correct partition based on the configuration in
 
 > Note: You should almost always omit `partition`. Set it *only* when your action
 > **requires** a *specialty* partition that is not automatically selected.
+
+
+## `<name>.output_file_path`
+`action.submit_options.<name>.output_file_path`: **string** - Set the directory 
+in which to place the output file when submitting jobs to the queue on cluster `<name>`. When omitted, 
+the file will be placed in the scheduler's default location (usually the location the action is run from).
+
+## `<name>.output_file_name`
+`action.submit_options.<name>.output_file_name`: **string** - Set the name of the output file created 
+when submitting jobs to the queue on cluster `<name>`. The name of the action can be included in the file name
+by including '{action_name}' within the specified string. Additionally, information about the job known to slurm
+can be included using certain replacement symbols (c.f. the symbols documented in the [slurm documentation](https://slurm.schedmd.com/sbatch.html#SECTION_FILENAME-PATTERN)). When omitted, the file is set to a default value of '{action_name}-%j.out'.

--- a/doc/src/workflow/action/submit-options.md
+++ b/doc/src/workflow/action/submit-options.md
@@ -60,11 +60,15 @@ will automatically determine the correct partition based on the configuration in
 
 ## `<name>.output_file_path`
 `action.submit_options.<name>.output_file_path`: **string** - Set the directory 
-in which to place the output file when submitting jobs to the queue on cluster `<name>`. When omitted, 
-the file will be placed in the scheduler's default location (usually the location the action is run from).
+in which to place the output file when submitting jobs to the queue on cluster `<name>`.
+When omitted, the file will be placed in the scheduler's default location (usually the 
+location the action is run from).
 
 ## `<name>.output_file_name`
-`action.submit_options.<name>.output_file_name`: **string** - Set the name of the output file created 
-when submitting jobs to the queue on cluster `<name>`. The name of the action can be included in the file name
-by including '{action_name}' within the specified string. Additionally, information about the job known to slurm
-can be included using certain replacement symbols (c.f. the symbols documented in the [slurm documentation](https://slurm.schedmd.com/sbatch.html#SECTION_FILENAME-PATTERN)). When omitted, the file is set to a default value of '{action_name}-%j.out'.
+`action.submit_options.<name>.output_file_name`: **string** - Set the name of the output
+file created when submitting jobs to the queue on cluster `<name>`. The name of the 
+action can be included in the file name by including '{action_name}' within the 
+specified string. Additionally, information about the job known to slurm can be 
+included using certain replacement symbols (c.f. the symbols documented in the 
+[slurm documentation](https://slurm.schedmd.com/sbatch.html#SECTION_FILENAME-PATTERN)).
+When omitted, the file is set to a default value of '{action_name}-%j.out'.

--- a/src/scheduler/slurm.rs
+++ b/src/scheduler/slurm.rs
@@ -94,7 +94,26 @@ impl Scheduler for Slurm {
             None => writeln!(preamble),
         };
 
-        let _ = writeln!(preamble, "#SBATCH --output={}-%j.out", action.name());
+        // The output file directory and filename
+        let output_path = action
+        .submit_options
+        .get(&self.cluster.name)
+        .map(|submit_options| {
+            let mut path = submit_options.output_file_path.as_deref().unwrap_or("").to_string();
+            if !path.is_empty()  && !path.ends_with('/') {
+                path.push('/');
+            }
+
+            match submit_options.output_file_name {
+                None => format!("{path}{}-%j.out", action.name()),
+                Some(ref name) => {
+                    let replaced_name = name.replace("{action_name}", &action.name());
+                    format!("{path}{replaced_name}")
+                }
+            }
+        })
+        .unwrap_or_else(|| format!("{}-%j.out", action.name())); //If submit_options is None, use the default filename
+        let _ = writeln!(preamble, "#SBATCH --output={}", output_path);
 
         if let Some(submit_options) = action.submit_options.get(&self.cluster.name) {
             user_partition = &submit_options.partition;
@@ -404,6 +423,7 @@ mod tests {
         assert!(!script.contains("#SBATCH --gpus-per-task"));
         assert!(script.contains("#SBATCH --time=180"));
         assert!(script.contains("#SBATCH --option=value"));
+        assert!(script.contains("#SBATCH --output=action-%j.out"));
     }
 
     #[test]
@@ -440,6 +460,60 @@ mod tests {
         println!("{script}");
 
         assert!(script.contains("#SBATCH --account=c"));
+    }
+
+    #[test]
+    #[parallel]
+    fn output() {
+        let (mut action, directories, slurm) = setup();
+        //With directory, not filename specified
+        action.submit_options.insert(
+            "cluster".into(),
+            SubmitOptions {
+                output_file_path: Some("dir".into()),
+                ..SubmitOptions::default()
+            },
+        );
+
+        let script = slurm
+            .make_script(&action, &directories, &PathBuf::default(), &HashMap::new())
+            .expect("valid script");
+        println!("{script}");
+
+        assert!(script.contains("#SBATCH --output=dir/action-%j.out"));
+
+        //With both directory and filename specified
+        action.submit_options.entry("cluster".into())
+            .and_modify(|submit_options| submit_options.output_file_name = Some("fname_{action_name}.out".into()));
+        
+        let script = slurm
+            .make_script(&action, &directories, &PathBuf::default(), &HashMap::new())
+            .expect("valid script");
+        println!("{script}");
+
+        assert!(script.contains("#SBATCH --output=dir/fname_action.out"));
+
+         //With filename, but not file directory specified
+         action.submit_options.entry("cluster".into())
+         .and_modify(|submit_options| submit_options.output_file_path = None);
+     
+        let script = slurm
+            .make_script(&action, &directories, &PathBuf::default(), &HashMap::new())
+            .expect("valid script");
+        println!("{script}");
+
+        assert!(script.contains("#SBATCH --output=fname_action.out"));
+
+        //With both filename and directory specified, directory ending in /
+        action.submit_options.entry("cluster".into())
+        .and_modify(|submit_options| submit_options.output_file_path = Some("dir/".into()));
+    
+       let script = slurm
+           .make_script(&action, &directories, &PathBuf::default(), &HashMap::new())
+           .expect("valid script");
+       println!("{script}");
+
+       assert!(script.contains("#SBATCH --output=dir/fname_action.out"));
     }
 
     #[test]

--- a/src/scheduler/slurm.rs
+++ b/src/scheduler/slurm.rs
@@ -70,6 +70,7 @@ pub struct ActiveSlurmJobs {
 }
 
 impl Scheduler for Slurm {
+    #[allow(clippy::too_many_lines)]
     fn make_script(
         &self,
         action: &Action,
@@ -95,25 +96,28 @@ impl Scheduler for Slurm {
         };
 
         // The output file directory and filename
-        let output_path = action
-        .submit_options
-        .get(&self.cluster.name)
-        .map(|submit_options| {
-            let mut path = submit_options.output_file_path.as_deref().unwrap_or("").to_string();
-            if !path.is_empty()  && !path.ends_with('/') {
-                path.push('/');
-            }
-
-            match submit_options.output_file_name {
-                None => format!("{path}{}-%j.out", action.name()),
-                Some(ref name) => {
-                    let replaced_name = name.replace("{action_name}", &action.name());
-                    format!("{path}{replaced_name}")
+        let output_path = action.submit_options.get(&self.cluster.name).map_or_else(
+            || format!("{}-%j.out", action.name()),
+            |submit_options| {
+                let mut path = submit_options
+                    .output_file_path
+                    .as_deref()
+                    .unwrap_or("")
+                    .to_string();
+                if !path.is_empty() && !path.ends_with('/') {
+                    path.push('/');
                 }
-            }
-        })
-        .unwrap_or_else(|| format!("{}-%j.out", action.name())); //If submit_options is None, use the default filename
-        let _ = writeln!(preamble, "#SBATCH --output={}", output_path);
+
+                match submit_options.output_file_name {
+                    None => format!("{path}{}-%j.out", action.name()),
+                    Some(ref name) => {
+                        let replaced_name = name.replace("{action_name}", action.name());
+                        format!("{path}{replaced_name}")
+                    }
+                }
+            },
+        );
+        let _ = writeln!(preamble, "#SBATCH --output={output_path}");
 
         if let Some(submit_options) = action.submit_options.get(&self.cluster.name) {
             user_partition = &submit_options.partition;
@@ -483,9 +487,13 @@ mod tests {
         assert!(script.contains("#SBATCH --output=dir/action-%j.out"));
 
         //With both directory and filename specified
-        action.submit_options.entry("cluster".into())
-            .and_modify(|submit_options| submit_options.output_file_name = Some("fname_{action_name}.out".into()));
-        
+        action
+            .submit_options
+            .entry("cluster".into())
+            .and_modify(|submit_options| {
+                submit_options.output_file_name = Some("fname_{action_name}.out".into());
+            });
+
         let script = slurm
             .make_script(&action, &directories, &PathBuf::default(), &HashMap::new())
             .expect("valid script");
@@ -493,10 +501,12 @@ mod tests {
 
         assert!(script.contains("#SBATCH --output=dir/fname_action.out"));
 
-         //With filename, but not file directory specified
-         action.submit_options.entry("cluster".into())
-         .and_modify(|submit_options| submit_options.output_file_path = None);
-     
+        //With filename, but not file directory specified
+        action
+            .submit_options
+            .entry("cluster".into())
+            .and_modify(|submit_options| submit_options.output_file_path = None);
+
         let script = slurm
             .make_script(&action, &directories, &PathBuf::default(), &HashMap::new())
             .expect("valid script");
@@ -505,15 +515,17 @@ mod tests {
         assert!(script.contains("#SBATCH --output=fname_action.out"));
 
         //With both filename and directory specified, directory ending in /
-        action.submit_options.entry("cluster".into())
-        .and_modify(|submit_options| submit_options.output_file_path = Some("dir/".into()));
-    
-       let script = slurm
-           .make_script(&action, &directories, &PathBuf::default(), &HashMap::new())
-           .expect("valid script");
-       println!("{script}");
+        action
+            .submit_options
+            .entry("cluster".into())
+            .and_modify(|submit_options| submit_options.output_file_path = Some("dir/".into()));
 
-       assert!(script.contains("#SBATCH --output=dir/fname_action.out"));
+        let script = slurm
+            .make_script(&action, &directories, &PathBuf::default(), &HashMap::new())
+            .expect("valid script");
+        println!("{script}");
+
+        assert!(script.contains("#SBATCH --output=dir/fname_action.out"));
     }
 
     #[test]

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -77,7 +77,7 @@ pub struct SubmitOptions {
 
     /// The partition.
     pub partition: Option<String>,
-    
+
     /// Output file path.
     pub output_file_path: Option<String>,
 
@@ -897,8 +897,14 @@ output_file_name = "output.txt"
         );
         assert_eq!(submit_options.custom, vec!["--option1", "--option2"]);
         assert_eq!(submit_options.partition, Some(String::from("gpu")));
-        assert_eq!(submit_options.output_file_path, Some(String::from("path/to/output")));
-        assert_eq!(submit_options.output_file_name, Some(String::from("output.txt")));
+        assert_eq!(
+            submit_options.output_file_path,
+            Some(String::from("path/to/output"))
+        );
+        assert_eq!(
+            submit_options.output_file_name,
+            Some(String::from("output.txt"))
+        );
     }
 
     #[test]

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -77,6 +77,12 @@ pub struct SubmitOptions {
 
     /// The partition.
     pub partition: Option<String>,
+    
+    /// Output file path.
+    pub output_file_path: Option<String>,
+
+    /// Output file name.
+    pub output_file_name: Option<String>,
 }
 
 /** The action definition.
@@ -856,6 +862,8 @@ value_file = "s"
         assert_eq!(submit_options.setup, None);
         assert!(submit_options.custom.is_empty());
         assert_eq!(submit_options.partition, None);
+        assert_eq!(submit_options.output_file_name, None);
+        assert_eq!(submit_options.output_file_path, None);
     }
 
     #[test]
@@ -868,6 +876,8 @@ account = "my_account"
 setup = "module load openmpi"
 custom = ["--option1", "--option2"]
 partition = "gpu"
+output_file_path = "path/to/output"
+output_file_name = "output.txt"
 "#;
         let workflow = Workflow::open_str(temp.path(), workflow).unwrap();
 
@@ -887,6 +897,8 @@ partition = "gpu"
         );
         assert_eq!(submit_options.custom, vec!["--option1", "--option2"]);
         assert_eq!(submit_options.partition, Some(String::from("gpu")));
+        assert_eq!(submit_options.output_file_path, Some(String::from("path/to/output")));
+        assert_eq!(submit_options.output_file_name, Some(String::from("output.txt")));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Added the option for the user to specify the name and directory of the files output by slurm. The field still populates as before if not specified.

## Motivation and context

Currently, output files are typically placed in the same directory as where the code is run, which may be undesirable depending on a given project's organization. 

## How has this been tested?

Unit tests were added to the workflow.rs and slurm.rs to that the output field bash file is properly instantiated based on the new options.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/row/blob/trunk/doc/src/developers/contributing.md).
- [x] I agree with the terms of the [**Row Contributor Agreement**](https://github.com/glotzerlab/row/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/src/contributors.md`) in the pull request source branch.
- [x] I have added a change log entry to `doc/src/release-notes.md`.
