### PR TITLE
Use env::home

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 env:
-  RUST_VERSION: 1.86.0
+  RUST_VERSION: 1.87.0
 
 jobs:
   pre-commit:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ env:
   name: row
   CARGO_TERM_COLOR: always
   CLICOLOR: 1
-  RUST_VERSION: 1.86.0
+  RUST_VERSION: 1.87.0
 
 jobs:
   source:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,7 @@ env:
   CARGO_TERM_COLOR: always
   ROW_COLOR: always
   CLICOLOR: 1
-  RUST_LATEST_VERSION: 1.86.0
+  RUST_LATEST_VERSION: 1.87.0
 
 jobs:
   unit_test:
@@ -34,13 +34,14 @@ jobs:
         rust:
           - 1.85.0
           - 1.86.0
+          - 1.87.0
         mode:
          - debug
 
         include:
         # Add a release build on linux with the latest version of rust
         - os: ubuntu-24.04
-          rust: 1.86.0
+          rust: 1.87.0
           mode: release
 
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,15 +455,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
 name = "human_format"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,7 +820,6 @@ dependencies = [
  "clap_complete",
  "console",
  "env_logger",
- "home",
  "human_format",
  "indicatif",
  "indicatif-log-bridge",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ clap-verbosity-flag = "3.0.2"
 clap_complete = { version = "4.5.48", features = ["unstable-dynamic"] }
 console = "0.15.11"
 env_logger = "0.11.6"
-home = "0.5.11"
 human_format = "1.1.0"
 indicatif = "0.17.11"
 indicatif-log-bridge = "0.2.3"

--- a/doc/src/release-notes.md
+++ b/doc/src/release-notes.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## 0.7.0 (not yet released)
+
+*Changed:*
+
+* Test with Rust 1.87.0.
+
 ## 0.6.0 (2025-05-02)
 
 *Highlights:*

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -157,7 +157,7 @@ impl Configuration {
     pub fn open() -> Result<Self, Error> {
         let home = match env::var("ROW_HOME") {
             Ok(row_home) => PathBuf::from(row_home),
-            Err(_) => home::home_dir().ok_or_else(Error::NoHome)?,
+            Err(_) => env::home_dir().ok_or_else(Error::NoHome)?,
         };
         let clusters_toml_path = home.join(".config").join("row").join("clusters.toml");
         Self::open_from_path(clusters_toml_path)

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -102,7 +102,7 @@ impl Configuration {
     pub fn open() -> Result<Self, Error> {
         let home = match env::var("ROW_HOME") {
             Ok(row_home) => PathBuf::from(row_home),
-            Err(_) => home::home_dir().ok_or_else(Error::NoHome)?,
+            Err(_) => env::home_dir().ok_or_else(Error::NoHome)?,
         };
         let launchers_toml_path = home.join(".config").join("row").join("launchers.toml");
         Self::open_from_path(launchers_toml_path)


### PR DESCRIPTION
## Description

<!-- Describe your changes. -->
Switch to `env::home_dir`.

## Motivation and context

Previously, `env::home_dir` was deprecated and requested that developers use another crate. Now, the `home` crate is deprecated and `env::home_dir` is not...

<!--- Why is this change required? What problem does it solve? -->

## How has this been tested?

<!--- Please describe how you tested your changes. -->
I verified that `row` accesses the config files from the expected home directory.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/row/blob/trunk/doc/src/developers/contributing.md).
- [x] I agree with the terms of the [**Row Contributor Agreement**](https://github.com/glotzerlab/row/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/src/contributors.md`) in the pull request source branch.
- [x] I have added a change log entry to `doc/src/release-notes.md`.
