### PR TITLE
Find products in subdirectories

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 env:
-  RUST_VERSION: 1.87.0
+  RUST_VERSION: 1.89.0
 
 jobs:
   pre-commit:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ env:
   name: row
   CARGO_TERM_COLOR: always
   CLICOLOR: 1
-  RUST_VERSION: 1.87.0
+  RUST_VERSION: 1.89.0
 
 jobs:
   source:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,7 @@ env:
   CARGO_TERM_COLOR: always
   ROW_COLOR: always
   CLICOLOR: 1
-  RUST_LATEST_VERSION: 1.87.0
+  RUST_LATEST_VERSION: 1.89.0
 
 jobs:
   unit_test:
@@ -32,16 +32,15 @@ jobs:
           - ubuntu-24.04
           - macos-14
         rust:
-          - 1.85.0
-          - 1.86.0
-          - 1.87.0
+          - 1.88.0
+          - 1.89.0
         mode:
          - debug
 
         include:
         # Add a release build on linux with the latest version of rust
         - os: ubuntu-24.04
-          rust: 1.87.0
+          rust: 1.89.0
           mode: release
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 /workflow.toml
+/test-workflow
 workspace
 .row
 .signac

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "row"
 version = "0.6.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 description = "Row is a command line tool that helps you manage workflows on HPC resources."
 homepage = "https://glotzerlab.engin.umich.edu"
 documentation = "https://row.readthedocs.io"

--- a/doc/src/release-notes.md
+++ b/doc/src/release-notes.md
@@ -2,9 +2,23 @@
 
 ## 0.7.0 (not yet released)
 
+*Highlights:*
+
+**Row** 0.7 allows users to produce product files in subdirectories.
+
+For example:
+```toml
+[[action]]
+products = ['file1.dat', 'subdir/file2.h5', 'long/path/to/file3.gsd']
+```
+
+*Added:*
+
+* `products` can now contain files in subdirectories.
+
 *Changed:*
 
-* Test with Rust 1.87.0.
+* Rust 1.88.0 is required to build **row** from source.
 
 ## 0.6.0 (2025-05-02)
 

--- a/doc/src/workflow/action/index.md
+++ b/doc/src/workflow/action/index.md
@@ -13,7 +13,7 @@ products = ["one.data"]
 name = "action_two"
 command = "python action_two.py {directories}"
 previous_actions = ["action_one"]
-products = ["two.data", "log.txt"]
+products = ["two.data", "output/log.txt"]
 launchers = ["openmp", "mpi"]
 [action.group]
 maximum_size = 8
@@ -110,6 +110,13 @@ must *all* be completed before this action may be executed. When omitted,
 action produces in the directory. When *all* products are present, that
 directory has *completed* the action. When omitted, `products` defaults
 to an empty array.
+
+A product file may be in a subdirectory under the directory. For example:
+```toml
+products = ["output/data.dcd", "a/long/path/to/data.h5"]
+```
+All elements in `products` must be relative paths and contain no parent
+directories (`../`).
 
 ## `[group]`
 

--- a/src/cli/directories.rs
+++ b/src/cli/directories.rs
@@ -163,11 +163,10 @@ pub fn print_matching<W: Write>(
         let groups = project.separate_into_groups(action, selected_directories)?;
 
         for (group_idx, group) in groups.iter().enumerate() {
-            if let Some(n) = args.n_groups {
-                if group_idx >= n {
+            if let Some(n) = args.n_groups
+                && group_idx >= n {
                     break;
                 }
-            }
 
             for directory in group {
                 // Format the directory status.

--- a/src/cli/directories.rs
+++ b/src/cli/directories.rs
@@ -164,9 +164,10 @@ pub fn print_matching<W: Write>(
 
         for (group_idx, group) in groups.iter().enumerate() {
             if let Some(n) = args.n_groups
-                && group_idx >= n {
-                    break;
-                }
+                && group_idx >= n
+            {
+                break;
+            }
 
             for directory in group {
                 // Format the directory status.

--- a/src/cli/scan.rs
+++ b/src/cli/scan.rs
@@ -55,12 +55,11 @@ pub fn scan(
 
     let mut matching_action_count = 0;
     for action in workflow.action {
-        if let Some(selection) = args.action.as_ref() {
-            if selection != action.name() {
+        if let Some(selection) = args.action.as_ref()
+            && selection != action.name() {
                 complete.remove(action.name());
                 continue;
             }
-        }
         trace!(
             "Including complete directories for action '{}'.",
             action.name()

--- a/src/cli/scan.rs
+++ b/src/cli/scan.rs
@@ -56,10 +56,11 @@ pub fn scan(
     let mut matching_action_count = 0;
     for action in workflow.action {
         if let Some(selection) = args.action.as_ref()
-            && selection != action.name() {
-                complete.remove(action.name());
-                continue;
-            }
+            && selection != action.name()
+        {
+            complete.remove(action.name());
+            continue;
+        }
         trace!(
             "Including complete directories for action '{}'.",
             action.name()

--- a/src/cli/submit.rs
+++ b/src/cli/submit.rs
@@ -134,9 +134,10 @@ pub fn submit<W: Write>(
         let mut job_count = 0;
         for group in groups {
             if let Some(n) = args.n
-                && action_directories.len() >= n {
-                    break;
-                }
+                && action_directories.len() >= n
+            {
+                break;
+            }
 
             cost = cost + action.resources.cost(group.len());
             action_directories.push((action.clone(), group.clone()));
@@ -155,9 +156,10 @@ pub fn submit<W: Write>(
         total_cost = total_cost + cost;
 
         if let Some(n) = args.n
-            && action_directories.len() >= n {
-                break;
-            }
+            && action_directories.len() >= n
+        {
+            break;
+        }
     }
 
     if action_directories.is_empty() {

--- a/src/cli/submit.rs
+++ b/src/cli/submit.rs
@@ -133,11 +133,10 @@ pub fn submit<W: Write>(
         let mut cost = ResourceCost::new();
         let mut job_count = 0;
         for group in groups {
-            if let Some(n) = args.n {
-                if action_directories.len() >= n {
+            if let Some(n) = args.n
+                && action_directories.len() >= n {
                     break;
                 }
-            }
 
             cost = cost + action.resources.cost(group.len());
             action_directories.push((action.clone(), group.clone()));
@@ -155,11 +154,10 @@ pub fn submit<W: Write>(
         }
         total_cost = total_cost + cost;
 
-        if let Some(n) = args.n {
-            if action_directories.len() >= n {
+        if let Some(n) = args.n
+            && action_directories.len() >= n {
                 break;
             }
-        }
     }
 
     if action_directories.is_empty() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,12 @@ pub enum Error {
     #[error("Action '{0}' must request more than 0 GPUs or omit `resources.gpus_per_process`.")]
     ZeroGpus(String),
 
+    #[error("Action '{0}' has an absolute product '{1}'. All products must be relative: `filename` or `some/dir/filename`.")]
+    AbsoluteProduct(String, String),
+
+    #[error("Invalid product product '{1}' in action '{0}'. Products must use '/' (not '\\') and must not contain './', '../', or '//'.")]
+    InvalidProduct(String, String),
+
     // submission errors
     #[error("Error encountered while executing action '{0}': {1}.")]
     ExecuteAction(String, String),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,10 +156,14 @@ pub enum Error {
     #[error("Action '{0}' must request more than 0 GPUs or omit `resources.gpus_per_process`.")]
     ZeroGpus(String),
 
-    #[error("Action '{0}' has an absolute product '{1}'. All products must be relative: `filename` or `some/dir/filename`.")]
+    #[error(
+        "Action '{0}' has an absolute product '{1}'. All products must be relative: `filename` or `some/dir/filename`."
+    )]
     AbsoluteProduct(String, String),
 
-    #[error("Invalid product product '{1}' in action '{0}'. Products must use '/' (not '\\') and must not contain './', '../', or '//'.")]
+    #[error(
+        "Invalid product product '{1}' in action '{0}'. Products must use '/' (not '\\') and must not contain './', '../', or '//'."
+    )]
     InvalidProduct(String, String),
 
     // submission errors

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -670,6 +670,23 @@ impl Workflow {
             if action.resources.gpus_per_process == Some(0) {
                 return Err(Error::ZeroGpus(action.name().into()));
             }
+
+            // To correctly find completed actions with produces in
+            // subdirectories, those products must not have absolute paths
+            // must use / not \, must not have '../' or './', and must not have
+            // repeated slashes '//'.
+            if let Some(products) = &action.products {
+                for product in products {
+                    let path = PathBuf::from(product.as_str());
+                    if path.has_root() || path.is_absolute() {
+                        return Err(Error::AbsoluteProduct(action.name().into(), product.into()));
+                    }
+
+                    if product.contains('\\') || product.contains("./") || product.contains("../") || product.contains("//") {
+                        return Err(Error::InvalidProduct(action.name().into(), product.into()));
+                    }
+                }
+            }
         }
 
         for action in &self.action {

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -682,7 +682,11 @@ impl Workflow {
                         return Err(Error::AbsoluteProduct(action.name().into(), product.into()));
                     }
 
-                    if product.contains('\\') || product.contains("./") || product.contains("../") || product.contains("//") {
+                    if product.contains('\\')
+                        || product.contains("./")
+                        || product.contains("../")
+                        || product.contains("//")
+                    {
                         return Err(Error::InvalidProduct(action.name().into(), product.into()));
                     }
                 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -2,16 +2,16 @@
 // Part of row, released under the BSD 3-Clause License.
 
 use indicatif::ProgressBar;
-use log::debug;
+use log::{debug, trace};
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsStr;
-use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::mpsc::{self, Receiver};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
+use std::{fs, io};
 
 use crate::workflow::Workflow;
 use crate::{Error, MIN_PROGRESS_BAR_SIZE, MultiProgressContainer, progress_styles};
@@ -108,10 +108,26 @@ pub fn find_completed_directories(
     let directories_mutex = Arc::new(Mutex::new(directories));
     let (sender, receiver) = mpsc::channel();
 
+    // It is extremely expensive to recursively traverse a directory tree.
+    // Doing so requires a stat() on every entry of every directory. To avoid
+    // this cost, build a list of subdirectories that *might* contain products
+    // and examine only those subdirectories via read_dir()..
+    let mut subdirectories = HashSet::new();
+
     let mut action_products: Vec<(String, Vec<String>)> = Vec::new();
     for action in &workflow.action {
         if !action.products().is_empty() {
             action_products.push((action.name().into(), action.products().into()));
+
+            for product in action.products() {
+                let subdirectory = PathBuf::from(product);
+                if let Some(parent) = subdirectory.parent()
+                    && parent != Path::new("")
+                {
+                    trace!("Scanning subdirectory `{}`.", parent.to_string_lossy());
+                    subdirectories.insert(PathBuf::from(parent));
+                }
+            }
         }
     }
 
@@ -123,6 +139,7 @@ pub fn find_completed_directories(
         let directories_mutex = directories_mutex.clone();
         let sender = sender.clone();
         let progress = progress.clone();
+        let subdirectories = subdirectories.clone();
 
         let thread_name = format!("find-completed-{i}");
         let handle =
@@ -158,6 +175,39 @@ pub fn find_completed_directories(
 
                             directory_contents.insert(entry_name);
                         }
+
+                        // Call read_dir only as many times as needed to scan
+                        // the subdirectories where products might be found.
+                        // Missing subdirectories is not an error.
+                        for subdirectory in &subdirectories {
+                            let subdirectory_path = directory_path.join(subdirectory);
+                            let read_dir = subdirectory_path.read_dir();
+
+                            if let Err(ref error) = read_dir
+                                && error.kind() == io::ErrorKind::NotFound
+                            {
+                                continue;
+                            }
+
+                            for entry in read_dir
+                                .map_err(|e| Error::DirectoryRead(subdirectory_path.clone(), e))?
+                            {
+                                let entry_name = entry
+                                    .map_err(|e| {
+                                        Error::DirectoryRead(subdirectory_path.clone(), e)
+                                    })?
+                                    .file_name();
+
+                                // directory_path (and by extension subdirectory_path)
+                                // are absolute. Use subdirectory joined with entry_name
+                                // to form a relative path matching what the user
+                                // provides in workflow.toml.
+                                let entry_path = subdirectory.join(entry_name);
+                                directory_contents.insert(entry_path.into_os_string());
+                            }
+                        }
+
+                        debug!("{directory_contents:?}");
 
                         for (action_name, products) in &action_products {
                             if products

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -88,6 +88,7 @@ to complete and then provides the list of completions.
 # Panics
 When unable to spawn threads.
 */
+#[allow(clippy::too_many_lines)]
 pub fn find_completed_directories(
     workflow: &Workflow,
     directories: Vec<PathBuf>,
@@ -206,8 +207,6 @@ pub fn find_completed_directories(
                                 directory_contents.insert(entry_path.into_os_string());
                             }
                         }
-
-                        debug!("{directory_contents:?}");
 
                         for (action_name, products) in &action_products {
                             if products
@@ -474,6 +473,16 @@ products = ["2"]
 name = "three"
 command = "c"
 products = ["3", "4"]
+
+[[action]]
+name = "four"
+command = "d"
+products = ["5", "long/sub/dir/6"]
+
+[[action]]
+name = "five"
+command = "e"
+products = ["62"]
 "#;
 
         temp.child("workspace")
@@ -511,6 +520,19 @@ products = ["3", "4"]
             .child("3")
             .touch()
             .unwrap();
+        temp.child("workspace")
+            .child("dir6")
+            .child("5")
+            .touch()
+            .unwrap();
+        temp.child("workspace")
+            .child("dir6")
+            .child("long")
+            .child("sub")
+            .child("dir")
+            .child("6")
+            .touch()
+            .unwrap();
 
         let workflow = Workflow::open_str(temp.path(), workflow).unwrap();
 
@@ -522,6 +544,7 @@ products = ["3", "4"]
                 PathBuf::from("dir3"),
                 PathBuf::from("dir4"),
                 PathBuf::from("dir5"),
+                PathBuf::from("dir6"),
             ],
             2,
             &mut multi_progress,
@@ -538,8 +561,10 @@ products = ["3", "4"]
         assert!(result["two"].contains(&PathBuf::from("dir2")));
         assert!(result["two"].contains(&PathBuf::from("dir3")));
         assert!(result["three"].contains(&PathBuf::from("dir4")));
+        assert_eq!(result["four"].len(), 1);
+        assert!(result["four"].contains(&PathBuf::from("dir6")));
 
-        assert!(!result.contains_key("four"));
+        assert!(!result.contains_key("five"));
     }
 
     #[test]

--- a/test-workflow/workflow.toml
+++ b/test-workflow/workflow.toml
@@ -1,4 +1,0 @@
-[[action]]
-name = "hello"
-command = 'echo "Hello, {directory}!"'
-resources.gpus_per_process = 0


### PR DESCRIPTION
## Description

<!-- Describe your changes. -->
Find products in subdirectories of the workspace directory. For example:
```toml
products = ['file.out', 'path/to/another/file.h5']
```

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Users expect that this should work.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #111 

## How has this been tested?

Unit tests and several manual tests workflows.

<!--- Please describe how you tested your changes. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/row/blob/trunk/doc/src/developers/contributing.md).
- [x] I agree with the terms of the [**Row Contributor Agreement**](https://github.com/glotzerlab/row/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/src/contributors.md`) in the pull request source branch.
- [ ] I have added a change log entry to `doc/src/release-notes.md`.
