### PR TITLE
Build release binaries with musl

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -12,23 +12,17 @@ on:
 
   workflow_dispatch:
 
-env:
-  RUST_VERSION: 1.89.0
-
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    # For unknown reasons, pre-commit fails with error: component download failed for cargo-x86_64-unknown-linux-gnu: could not rename downloaded file ...
-    # unless we install with rustup first manually.
-    - name: Update rust
-      run: rustup install "$RUST_VERSION" --no-self-update && rustup default "${RUST_VERSION}"
-    - name: Install rustfmt
-      run: rustup component add rustfmt
-    - name: Install clippy
-      run: rustup component add clippy
+    - name: Configure Rust
+      uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
+      with:
+        toolchain: 1.89.0
+        components: rustfmt,clippy
     - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
         path: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,6 @@ env:
   name: row
   CARGO_TERM_COLOR: always
   CLICOLOR: 1
-  RUST_VERSION: 1.89.0
 
 jobs:
   source:
@@ -94,10 +93,10 @@ jobs:
     strategy:
       matrix:
         target:
-        - x86_64-unknown-linux-gnu
+        - x86_64-unknown-linux-musl
         - aarch64-apple-darwin
         include:
-        - target: x86_64-unknown-linux-gnu
+        - target: x86_64-unknown-linux-musl
           runner: ubuntu-22.04
         - target: aarch64-apple-darwin
           runner: macos-14
@@ -107,10 +106,13 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Determine filename-safe ref from GITHUB_REF_NAME
       run: echo ref="$(echo "${GITHUB_REF_NAME}" | sed  -e 's/\//-/g')" >> "$GITHUB_ENV"
-    - name: Update rust
-      run: rustup install "$RUST_VERSION" --no-self-update && rustup default "$RUST_VERSION"
-    - name: Check rust installation
-      run: rustc -vV
+    - name: Configure Rust
+      uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
+      with:
+        toolchain: 1.89.0
+    - name: Install musl-tools on Linux
+      run: sudo apt-get update --yes && sudo apt-get install --yes musl-tools
+      if: contains(matrix.target, 'musl')
     - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
         path: |
@@ -118,7 +120,7 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: ${{ runner.os }}-rust-${{ env.RUST_VERSION }}-cargo-release-binary-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-rust-1.89.0-cargo-release-binary-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
     - name: Build
       run: cargo build --locked --bin "${name}" --release --target ${{ matrix.target }}
     - name: Check output
@@ -161,10 +163,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - name: Update rust
-      run: rustup install "$RUST_VERSION" --no-self-update && rustup default "$RUST_VERSION"
-    - name: Check rust installation
-      run: rustc -vV
+    - name: Configure Rust
+      uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
+      with:
+        toolchain: 1.89.0
     - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
         path: |
@@ -172,7 +174,7 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: ${{ runner.os }}-rust-${{ env.RUST_VERSION }}-cargo-publish-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-rust-1.89.0-cargo-publish-${{ hashFiles('**/Cargo.lock') }}
     - name: Dry run
       run: cargo publish --all-features --dry-run
     - name: Publish to crates.io

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -107,9 +107,11 @@ jobs:
     - name: Determine filename-safe ref from GITHUB_REF_NAME
       run: echo ref="$(echo "${GITHUB_REF_NAME}" | sed  -e 's/\//-/g')" >> "$GITHUB_ENV"
     - name: Configure Rust
+      id: rust_toolchain
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
       with:
         toolchain: 1.89.0
+        targets: ${{ matrix.target }}
     - name: Install musl-tools on Linux
       run: sudo apt-get update --yes && sudo apt-get install --yes musl-tools
       if: contains(matrix.target, 'musl')
@@ -120,7 +122,7 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: ${{ runner.os }}-rust-1.89.0-cargo-release-binary-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-rust-${{steps.rust_toolchain.outputs.name}}-cargo-release-binary-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
     - name: Build
       run: cargo build --locked --bin "${name}" --release --target ${{ matrix.target }}
     - name: Check output
@@ -164,6 +166,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Configure Rust
+      id: rust_toolchain
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
       with:
         toolchain: 1.89.0
@@ -174,7 +177,7 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: ${{ runner.os }}-rust-1.89.0-cargo-publish-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-rust-${{steps.rust_toolchain.outputs.cachekey}}-cargo-publish-${{ hashFiles('**/Cargo.lock') }}
     - name: Dry run
       run: cargo publish --all-features --dry-run
     - name: Publish to crates.io

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,6 +46,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Configure Rust
+      id: rust_toolchain
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
       with:
         toolchain: ${{ matrix.rust }}
@@ -56,7 +57,7 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: ${{ runner.os }}-rust-${{ matrix.rust }}-cargo-unit-test-${{ matrix.mode }}-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-rust-${{steps.rust_toolchain.outputs.name}}-cargo-unit-test-${{ matrix.mode }}-${{ hashFiles('**/Cargo.lock') }}
     - name: Build
       run: cargo build ${{ matrix.mode == 'release' && '--release' || '' }} --verbose
     - name: Run tests
@@ -69,6 +70,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Configure Rust
+      id: rust_toolchain
       uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
       with:
         toolchain: 1.89.0
@@ -79,7 +81,7 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: ${{ runner.os }}-rust-1.89.0-cargo-execute-tutorials-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-rust-${{steps.rust_toolchain.outputs.name}}-cargo-execute-tutorials-${{ hashFiles('**/Cargo.lock') }}
     - name: Install
       run: cargo install --path . --locked --verbose
     - name: Run hello.sh

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,6 @@ env:
   CARGO_TERM_COLOR: always
   ROW_COLOR: always
   CLICOLOR: 1
-  RUST_LATEST_VERSION: 1.89.0
 
 jobs:
   unit_test:
@@ -46,10 +45,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - name: Update rust
-      run: rustup install ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
-    - name: Check rust installation
-      run: rustc -vV
+    - name: Configure Rust
+      uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
+      with:
+        toolchain: ${{ matrix.rust }}
     - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
         path: |
@@ -69,10 +68,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - name: Update rust
-      run: rustup install "$RUST_LATEST_VERSION" --no-self-update && rustup default "$RUST_LATEST_VERSION"
-    - name: Check rust installation
-      run: rustc -vV
+    - name: Configure Rust
+      uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
+      with:
+        toolchain: 1.89.0
     - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:
         path: |
@@ -80,7 +79,7 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: ${{ runner.os }}-rust-${{ env.RUST_LATEST_VERSION }}-cargo-execute-tutorials-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-rust-1.89.0-cargo-execute-tutorials-${{ hashFiles('**/Cargo.lock') }}
     - name: Install
       run: cargo install --path . --locked --verbose
     - name: Run hello.sh

--- a/doc/src/release-notes.md
+++ b/doc/src/release-notes.md
@@ -1,5 +1,12 @@
 # Release notes
 
+## 0.7.1 (2025-08-21)
+
+*Fixed:*
+
+* Statically link Linux binaries so that `cargo binstall row` installs a working version
+  even on old Linux distributions.
+
 ## 0.7.0 (2025-08-11)
 
 *Highlights:*


### PR DESCRIPTION
## Description

<!-- Describe your changes. -->
Use musl when building release binaries.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Allow row installed via `cargo binstall` to execute on old Linux distributions.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #116.

## How has this been tested?

<!--- Please describe how you tested your changes. -->
- [x] Test built artifact on Purdue Anvil.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/row/blob/trunk/doc/src/developers/contributing.md).
- [x] I agree with the terms of the [**Row Contributor Agreement**](https://github.com/glotzerlab/row/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/src/contributors.md`) in the pull request source branch.
- [x] I have added a change log entry to `doc/src/release-notes.md`.
