### PR TITLE
Fix sbatch errors on some clusters

### DIFF
--- a/codebook.toml
+++ b/codebook.toml
@@ -1,5 +1,10 @@
 words = [
     "cpus",
     "gpus",
+    "mpi",
+    "noheader",
+    "ntasks",
+    "sbatch",
     "slurm",
+    "squeue",
 ]

--- a/doc/src/clusters/cluster.md
+++ b/doc/src/clusters/cluster.md
@@ -52,6 +52,12 @@ be one of:
 * `"slurm"`
 * `"bash"`
 
+## slurm_gpus_per_task
+
+`cluster.slurm_gpus_per_task`: **string** - Set the `sbatch` command line option that
+selects the number of gpus per task (used only by the `slurm` scheduler). When omitted,
+`slurm_gpus_per_task` defaults to `--gpus-per-task=`.
+
 ## submit_options
 
 `cluster.submit_options`: **array** of **strings** - Scheduler submission options that

--- a/doc/src/release-notes.md
+++ b/doc/src/release-notes.md
@@ -9,6 +9,7 @@
 *Fixed:*
 
 * Fix "JSON Pointers" example.
+* Handle non-numeric suffixes written by `sbatch`.
 
 ## 0.7.1 (2025-08-21)
 

--- a/doc/src/release-notes.md
+++ b/doc/src/release-notes.md
@@ -5,6 +5,7 @@
 *Added:*
 
 * Rayon launcher that prefixes commands with `RAYON_NUM_THREADS={T}`.
+* `slurm_gpus_per_task` cluster option.
 
 *Fixed:*
 

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -93,6 +93,7 @@ fn andes() -> Cluster {
                 ..Partition::default()
             },
         ],
+        ..Cluster::default()
     }
 }
 
@@ -153,6 +154,7 @@ fn anvil() -> Cluster {
                 ..Partition::default()
             },
         ],
+        ..Cluster::default()
     }
 }
 
@@ -211,6 +213,7 @@ fn delta() -> Cluster {
                 ..Partition::default()
             },
         ],
+        ..Cluster::default()
     }
 }
 
@@ -231,6 +234,7 @@ fn frontier() -> Cluster {
                 ..Partition::default()
             },
         ],
+        ..Cluster::default()
     }
 }
 
@@ -300,6 +304,7 @@ fn greatlakes() -> Cluster {
                 ..Partition::default()
             },
         ],
+        ..Cluster::default()
     }
 }
 
@@ -314,6 +319,7 @@ fn none() -> Cluster {
             name: "none".into(),
             ..Partition::default()
         }],
+        ..Cluster::default()
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -346,6 +346,7 @@ pub fn parse_directories<F>(
 where
     F: FnOnce() -> Result<Vec<PathBuf>, crate::Error>,
 {
+    #[allow(clippy::cmp_owned, reason = "Requires Rust 1.91.1 to avoid")]
     if query_directories.len() == 1 && query_directories[0] == PathBuf::from("-") {
         trace!("Reading directories from stdin.");
         query_directories.clear();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -346,7 +346,7 @@ pub fn parse_directories<F>(
 where
     F: FnOnce() -> Result<Vec<PathBuf>, crate::Error>,
 {
-    if query_directories.len() == 1 && *query_directories[0] == *"-" {
+    if query_directories.len() == 1 && query_directories[0] == PathBuf::from("-") {
         trace!("Reading directories from stdin.");
         query_directories.clear();
         for line in io::stdin().lines() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -346,7 +346,7 @@ pub fn parse_directories<F>(
 where
     F: FnOnce() -> Result<Vec<PathBuf>, crate::Error>,
 {
-    if query_directories.len() == 1 && query_directories[0] == PathBuf::from("-") {
+    if query_directories.len() == 1 && *query_directories[0] == *"-" {
         trace!("Reading directories from stdin.");
         query_directories.clear();
         for line in io::stdin().lines() {

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -27,6 +27,10 @@ pub struct Configuration {
     pub cluster: Vec<Cluster>,
 }
 
+fn default_slurm_gpus_per_task() -> String {
+    "--gpus-per-task=".to_string()
+}
+
 /** Cluster
 
 [`Cluster`] stores everything needed to define a single cluster. It is read from the `clusters.toml`
@@ -46,9 +50,26 @@ pub struct Cluster {
     /// The partitions in the cluster's queue.
     pub partition: Vec<Partition>,
 
+    /// Slurm command line option to set gpus per task.
+    #[serde(default = "default_slurm_gpus_per_task")]
+    pub slurm_gpus_per_task: String,
+
     /// Submit options to include in every job submitted to this cluster.
     #[serde(default)]
     pub submit_options: Vec<String>,
+}
+
+impl Default for Cluster {
+    fn default() -> Self {
+        Self {
+            name: "cluster".to_string(),
+            identify: IdentificationMethod::Always(true),
+            scheduler: SchedulerType::Bash,
+            submit_options: Vec::new(),
+            slurm_gpus_per_task: default_slurm_gpus_per_task(),
+            partition: Vec::new(),
+        }
+    }
 }
 
 /// Methods to identify clusters.
@@ -402,6 +423,7 @@ mod tests {
                 scheduler: SchedulerType::Bash,
                 partition: Vec::new(),
                 submit_options: Vec::new(),
+                ..Cluster::default()
             },
             Cluster {
                 name: "cluster1".into(),
@@ -409,6 +431,7 @@ mod tests {
                 scheduler: SchedulerType::Bash,
                 partition: Vec::new(),
                 submit_options: Vec::new(),
+                ..Cluster::default()
             },
             Cluster {
                 name: "cluster2".into(),
@@ -416,6 +439,7 @@ mod tests {
                 scheduler: SchedulerType::Bash,
                 partition: Vec::new(),
                 submit_options: Vec::new(),
+                ..Cluster::default()
             },
             Cluster {
                 name: "cluster3".into(),
@@ -423,6 +447,7 @@ mod tests {
                 scheduler: SchedulerType::Bash,
                 partition: Vec::new(),
                 submit_options: Vec::new(),
+                ..Cluster::default()
             },
             Cluster {
                 name: "cluster4".into(),
@@ -430,6 +455,7 @@ mod tests {
                 scheduler: SchedulerType::Bash,
                 partition: Vec::new(),
                 submit_options: Vec::new(),
+                ..Cluster::default()
             },
         ];
         let cluster_configuration = Configuration { cluster: clusters };
@@ -607,6 +633,7 @@ mod tests {
             scheduler: SchedulerType::Bash,
             partition: partitions,
             submit_options: Vec::new(),
+            ..Cluster::default()
         };
 
         let cpu_resources = Resources {

--- a/src/scheduler/bash.rs
+++ b/src/scheduler/bash.rs
@@ -456,7 +456,6 @@ mod tests {
     use speedate::Duration;
 
     use crate::builtin::BuiltIn;
-    use crate::cluster::{IdentificationMethod, SchedulerType};
     use crate::launcher;
     use crate::workflow::Walltime;
     use crate::workflow::{Resources, SubmitOptions};
@@ -792,13 +791,7 @@ mod tests {
     #[parallel]
     fn scheduler() {
         let (action, directories, launchers) = setup();
-        let cluster = Cluster {
-            name: "cluster".into(),
-            scheduler: SchedulerType::Bash,
-            identify: IdentificationMethod::Always(false),
-            partition: Vec::new(),
-            submit_options: Vec::new(),
-        };
+        let cluster = Cluster::default();
         let script = Bash::new(cluster, launchers)
             .make_script(&action, &directories, &PathBuf::default(), &HashMap::new())
             .expect("Valid script");

--- a/src/scheduler/slurm.rs
+++ b/src/scheduler/slurm.rs
@@ -142,7 +142,11 @@ impl Scheduler for Slurm {
             let _ = writeln!(preamble, "#SBATCH --cpus-per-task={threads_per_process}");
         }
         if let Some(gpus_per_process) = action.resources.gpus_per_process {
-            let _ = writeln!(preamble, "#SBATCH --gpus-per-task={gpus_per_process}");
+            let _ = writeln!(
+                preamble,
+                "#SBATCH {}{gpus_per_process}",
+                self.cluster.slurm_gpus_per_task
+            );
 
             if let Some(ref gpus_per_node) = partition.gpus_per_node {
                 let n_nodes = action
@@ -225,7 +229,7 @@ impl Scheduler for Slurm {
         directory_values: &HashMap<PathBuf, Value>,
         should_terminate: Arc<AtomicBool>,
     ) -> Result<Option<u32>, Error> {
-        debug!("Submtitting '{}' with sbatch.", action.name());
+        debug!("Submitting '{}' with sbatch.", action.name());
 
         // output() below is blocking with no convenient way to interrupt it.
         // If the user pressed ctrl-C, let the current call to submit() finish
@@ -384,6 +388,7 @@ mod tests {
             scheduler: SchedulerType::Slurm,
             partition: vec![Partition::default()],
             submit_options: Vec::new(),
+            ..Cluster::default()
         };
 
         let slurm = Slurm::new(cluster, launchers.by_cluster("cluster"));
@@ -582,6 +587,22 @@ mod tests {
 
     #[test]
     #[parallel]
+    fn custom_gpus_per_task() {
+        let (mut action, directories, mut slurm) = setup();
+        slurm.cluster.slurm_gpus_per_task = "--custom=".to_string();
+
+        action.resources.gpus_per_process = Some(5);
+
+        let script = slurm
+            .make_script(&action, &directories, &PathBuf::default(), &HashMap::new())
+            .expect("valid script");
+        println!("{script}");
+
+        assert!(script.contains("#SBATCH --custom=5"));
+    }
+
+    #[test]
+    #[parallel]
     fn mem_per_cpu() {
         let (mut action, directories, _) = setup();
 
@@ -595,6 +616,7 @@ mod tests {
                 memory_per_cpu_mb: Some(5),
                 ..Partition::default()
             }],
+            ..Cluster::default()
         };
 
         let slurm = Slurm::new(cluster, launchers.by_cluster("cluster"));
@@ -638,6 +660,7 @@ mod tests {
                 memory_per_gpu_mb: Some(12),
                 ..Partition::default()
             }],
+            ..Cluster::default()
         };
 
         let slurm = Slurm::new(cluster, launchers.by_cluster("cluster"));
@@ -683,6 +706,7 @@ mod tests {
                 cpus_per_node: Some(10),
                 ..Partition::default()
             }],
+            ..Cluster::default()
         };
 
         let slurm = Slurm::new(cluster, launchers.by_cluster("cluster"));
@@ -712,6 +736,7 @@ mod tests {
                 gpus_per_node: Some(5),
                 ..Partition::default()
             }],
+            ..Cluster::default()
         };
 
         let slurm = Slurm::new(cluster, launchers.by_cluster("cluster"));

--- a/src/scheduler/slurm.rs
+++ b/src/scheduler/slurm.rs
@@ -262,7 +262,7 @@ impl Scheduler for Slurm {
         if output.status.success() {
             let job_id_string = str::from_utf8(&output.stdout).expect("Valid UTF-8 output");
             let job_id = job_id_string
-                .trim_end_matches(char::is_whitespace)
+                .trim_end_matches(|c| !char::is_numeric(c))
                 .parse::<u32>()
                 .map_err(|_| Error::UnexpectedOutput("sbatch".into(), job_id_string.into()))?;
             Ok(Some(job_id))


### PR DESCRIPTION
## Description

<!-- Describe your changes. -->
* Ignore all non-numeric output from `sbatch`.
* Allow users to override the string `--gpus-per-task` in generated slurm scripts.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Solve issues reported in #194.

## How has this been tested?

<!--- Please describe how you tested your changes. -->
Unit tests and test jobs on a SLURM cluster.

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/row/blob/trunk/doc/src/developers/contributing.md).
- [X] I agree with the terms of the [**Row Contributor Agreement**](https://github.com/glotzerlab/row/blob/trunk/ContributorAgreement.md).
- [X] My name is on the list of contributors (`doc/src/contributors.md`) in the pull request source branch.
- [X] I have added a change log entry to `doc/src/release-notes.md`.
