### PR TITLE
add extended partition for frontier

### DIFF
--- a/doc/src/contributors.md
+++ b/doc/src/contributors.md
@@ -10,3 +10,4 @@ The following people have contributed to the development of **row**:
 * Corwin Kerr, University of Michigan
 * Trevor Teague, University of Michigan
 * Jared Shi, University of Michigan
+* Philipp Schönhöfer, University of Michigan

--- a/doc/src/release-notes.md
+++ b/doc/src/release-notes.md
@@ -4,6 +4,8 @@
 
 *Added:*
 
+* Add 'extended' as a partition for Frontier (#389).
+
 *Changed:*
 
 * Build the documentation with mdBook 0.5.4 (#360).

--- a/src/builtin.rs
+++ b/src/builtin.rs
@@ -233,6 +233,15 @@ fn frontier() -> Cluster {
                 gpus_per_node: Some(8),
                 ..Partition::default()
             },
+            // The following partitions may only be selected manually.
+            Partition {
+                name: "extended".into(),
+                maximum_gpus_per_job: Some(512),
+                warn_gpus_not_multiple_of: Some(8),
+                gpus_per_node: Some(8),
+                prevent_auto_select: true,
+                ..Partition::default()
+            },
         ],
         ..Cluster::default()
     }


### PR DESCRIPTION
## Description

Add 'extended' to the available partitions on Frontier.

## Motivation and context

To finish some of our simulations we need a smaller number of nodes on GPU. This allows us to manually change the partition to 'extended'.

## How has this been tested?

It compiles, but has not been tested on Frontier yet.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/row/blob/trunk/doc/src/developers/contributing.md).
- [x] I agree with the terms of the [**Row Contributor Agreement**](https://github.com/glotzerlab/row/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/src/contributors.md`) in the pull request source branch.
- [x] I have added a change log entry to `doc/src/release-notes.md`.
